### PR TITLE
Css 10875 deployment fixes

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -93,7 +93,12 @@ config:
     external-hostname:
       description: |
         The DNS listing used for external connections.
-        Will default to the name of the deployed application.
+      type: string
+
+    external-gms-hostname:
+      description: |
+        The DNS listing used for external connections to GMS service.
+        Will not be exposed if unset.
       type: string
     
     tls-secret-name:

--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -331,7 +331,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 40
+LIBPATCH = 41
 
 PYDEPS = ["ops>=2.0.0"]
 
@@ -609,7 +609,7 @@ SECRET_GROUPS = SecretGroupsAggregate()
 class CachedSecret:
     """Locally cache a secret.
 
-    The data structure is precisely re-using/simulating as in the actual Secret Storage
+    The data structure is precisely reusing/simulating as in the actual Secret Storage
     """
 
     KNOWN_MODEL_ERRORS = [MODEL_ERRORS["no_label_and_uri"], MODEL_ERRORS["owner_no_refresh"]]
@@ -2363,7 +2363,6 @@ class DataPeerData(RequirerData, ProviderData):
     def _delete_relation_data(self, relation: Relation, fields: List[str]) -> None:
         """Delete data available (directily or indirectly -- i.e. secrets) from the relation for owner/this_app."""
         if self.secret_fields and self.deleted_label:
-
             _, normal_fields = self._process_secret_fields(
                 relation,
                 self.secret_fields,

--- a/lib/charms/data_platform_libs/v0/data_models.py
+++ b/lib/charms/data_platform_libs/v0/data_models.py
@@ -168,7 +168,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 5
 
 PYDEPS = ["ops>=2.0.0", "pydantic>=1.10,<2"]
 
@@ -209,7 +209,7 @@ def validate_params(cls: Type[T]):
     """
 
     def decorator(
-        f: Callable[[CharmBase, ActionEvent, Union[T, ValidationError]], G]
+        f: Callable[[CharmBase, ActionEvent, Union[T, ValidationError]], G],
     ) -> Callable[[CharmBase, ActionEvent], G]:
         @wraps(f)
         def event_wrapper(self: CharmBase, event: ActionEvent):
@@ -287,7 +287,7 @@ def parse_relation_data(
                 Optional[Union[UnitModel, ValidationError]],
             ],
             G,
-        ]
+        ],
     ) -> Callable[[CharmBase, RelationEvent], G]:
         @wraps(f)
         def event_wrapper(self: CharmBase, event: RelationEvent):

--- a/src/charm.py
+++ b/src/charm.py
@@ -162,7 +162,7 @@ class DatahubK8SOperatorCharm(TypedCharmBase[CharmConfig]):
             backend_protocol="HTTP",
         )
 
-        if self.config.get("external_gms_hostname"):
+        if self.config["external_gms_hostname"]:
             require_nginx_route(
                 charm=self,
                 service_hostname=self.config["external_gms_hostname"],

--- a/src/charm.py
+++ b/src/charm.py
@@ -162,6 +162,16 @@ class DatahubK8SOperatorCharm(TypedCharmBase[CharmConfig]):
             backend_protocol="HTTP",
         )
 
+        if self.config.get("external_gms_hostname"):
+            require_nginx_route(
+                charm=self,
+                service_hostname=self.config["external_gms_hostname"],
+                service_name=f"{self.app.name}-gms",
+                service_port=literals.GMS_PORT,
+                tls_secret_name="",  # nosec
+                backend_protocol="HTTP",
+            )
+
     @log_event_handler(logger)
     def _on_pebble_ready(self, event: ops.PebbleReadyEvent):
         """Handle pebble-ready event.

--- a/src/literals.py
+++ b/src/literals.py
@@ -7,6 +7,7 @@ DB_NAME = "datahub_db"
 PLACEHOLDER_INDEX = "datahub_index"
 PLACEHOLDER_TOPIC = "datahub_topic"
 FRONTEND_PORT = 9002
+GMS_PORT = 8080
 
 RUNNER_SRC_PATH = ("src", "scripts", "runner.sh")
 RUNNER_DEST_PATH = "/charm-external/runner.sh"

--- a/src/scripts/init-truststore.sh
+++ b/src/scripts/init-truststore.sh
@@ -6,8 +6,11 @@
 CERT_EXISTS=$(/usr/lib/jvm/java-17-openjdk/bin/keytool -list -cacerts -alias "$CERT_ALIAS" -storepass "changeit" 2>/dev/null)
 
 if [ -n "$CERT_EXISTS" ]; then
-  echo "Certificate with alias '$CERT_ALIAS' already exists. Deleting the existing certificate."
-  /usr/lib/jvm/java-17-openjdk/bin/keytool -delete -cacerts -alias "$CERT_ALIAS" -storepass "changeit"
+  # TODO (mertalpt): Room for improvement.
+  # This is used to import Opensearch CA certificates, which are from Let's Encrypt.
+  # It is very unlikely that those will change in content but not impossible.
+  echo "Certificate with alias '$CERT_ALIAS' already exists. Skipping initialization."
+  exit 0
 fi
 
 # Add the root CA certificate to the cacerts

--- a/src/services.py
+++ b/src/services.py
@@ -244,7 +244,7 @@ class FrontendService(AbstractService):
             Whether the service should be enabled.
         """
         is_ready = cls.is_ready(context)
-        checks = (context.charm._state.frontend_truststore_initialized is True,)
+        checks = (True,)
         return is_ready and all(checks)
 
     @classmethod
@@ -362,12 +362,6 @@ class FrontendService(AbstractService):
             logger.info("datahub-frontend is not ready to be initialized, skipping initialization")
             return False
 
-        # The only initialization step currently is to set up truststore for Opensearch SSL.
-        check_frontend_truststore = context.charm._state.frontend_truststore_initialized is True
-        if check_frontend_truststore:
-            logger.debug("datahub-frontend is already initialized, skipping initialization")
-            return False
-
         certificates = context.charm._state.opensearch_connection["tls-ca"]
         root_ca_cert = utils.split_certificates(certificates)[1]
 
@@ -394,7 +388,6 @@ class FrontendService(AbstractService):
             raise exceptions.InitializationFailedError("failed to initialize truststores for datahub-frontend")
 
         logger.info("Successful truststore initialization for datahub-frontend")
-        context.charm._state.frontend_truststore_initialized = True
         return True
 
 
@@ -425,7 +418,7 @@ class GMSService(AbstractService):
             Whether the service should be enabled.
         """
         is_ready = cls.is_ready(context)
-        checks = (context.charm._state.gms_truststore_initialized is True,)
+        checks = (True,)
         return is_ready and all(checks)
 
     @classmethod
@@ -551,12 +544,6 @@ class GMSService(AbstractService):
             logger.info("datahub-gms is not ready to be initialized, skipping initialization")
             return False
 
-        # The only initialization step currently is to set up truststore for Opensearch SSL.
-        check_gms_truststore = context.charm._state.gms_truststore_initialized is True
-        if check_gms_truststore:
-            logger.debug("datahub-gms is already initialized, skipping initialization")
-            return False
-
         certificates = context.charm._state.opensearch_connection["tls-ca"]
         root_ca_cert = utils.split_certificates(certificates)[1]
 
@@ -583,7 +570,6 @@ class GMSService(AbstractService):
             raise exceptions.InitializationFailedError("failed to initialize truststores for datahub-gms")
 
         logger.info("Successful truststore initialization for datahub-gms")
-        context.charm._state.gms_truststore_initialized = True
         return True
 
 
@@ -1088,12 +1074,6 @@ class UpgradeService(AbstractService):
             logger.info("Already ran datahub-upgrade, skipping initialization")
             return False
 
-        # We need to ensure that the truststore is configured first.
-        check_upgrade_truststore = context.charm._state.upgrade_truststore_initialized
-        if check_upgrade_truststore:
-            logger.debug("datahub-upgrade truststore is already initialized")
-            return False
-
         check_opensearch = utils.get_from_optional_dict(context.charm._state.opensearch_connection, "initialized")
         if not check_opensearch:
             logger.info("Opensearch is not initialized yet, skipping running datahub-upgrade")
@@ -1158,5 +1138,4 @@ class UpgradeService(AbstractService):
             raise exceptions.InitializationFailedError("failed to run jobs for datahub-upgrade")
 
         logger.info("Successful datahub-upgrade run")
-        context.charm._state.ran_upgrade = True
         return True

--- a/src/structured_config.py
+++ b/src/structured_config.py
@@ -21,6 +21,7 @@ class CharmConfig(BaseConfigModel):
         kafka_topic_prefix: Prefix to use for Kafka topic names.
         opensearch_index_prefix: Prefix to use for Opensearch indexes.
         external_hostname: Hostname of unit visible to outside.
+        external_gms_hostname: Hostname of the GMS service visible to outside.
         tls_secret_name: Name of the k8s secret to use for the TLS certificate.
     """
 
@@ -29,6 +30,7 @@ class CharmConfig(BaseConfigModel):
     kafka_topic_prefix: Optional[str] = None
     opensearch_index_prefix: Optional[str] = None
     external_hostname: Optional[str] = None
+    external_gms_hostname: Optional[str] = None
     tls_secret_name: Optional[str] = None
 
     @field_validator("*", mode="before")

--- a/tox.ini
+++ b/tox.ini
@@ -92,8 +92,8 @@ deps =
     {[testenv]deps}
     ipdb==0.13.9
     juju==3.5.2.0
-    pytest-operator==0.35.0
-    pytest-asyncio==0.21
+    pytest-operator==0.40.0
+    pytest-asyncio==0.21.2
 allowlist_externals =
     sudo
     sysctl

--- a/tox.ini
+++ b/tox.ini
@@ -99,7 +99,7 @@ commands =
 description = Run integration tests
 deps =
     ipdb==0.13.9
-    juju==3.5.2.0
+    juju==3.5.2.1
     pytest==7.1.3
     pytest-operator==0.35.0
     temporalio==1.6.0

--- a/tox.ini
+++ b/tox.ini
@@ -14,24 +14,6 @@ tests_path = {tox_root}/tests
 all_path = {[vars]src_path} {[vars]tests_path}
 
 [testenv]
-deps =
-    mypy==1.15.0
-    pylint==3.3.4
-    pydocstyle==6.3.0
-    pytest==8.3.4
-    black==22.8.0
-    isort==5.10.1
-    codespell==2.2.1
-    flake8>=7.0.0
-    flake8-builtins==2.5.0
-    flake8-copyright==0.2.4
-    flake8-docstrings==1.7.0
-    flake8-docstrings-complete==1.4.1
-    flake8-test-docs==1.0.8
-    pyproject-flake8==7.0.0
-    pep8-naming==0.14.1
-    coverage[toml]==7.6.12
-    -r {tox_root}/requirements.txt
 set_env =
     PYTHONPATH = {tox_root}/lib:{[vars]src_path}
     PYTHONBREAKPOINT=pdb.set_trace
@@ -43,12 +25,31 @@ pass_env =
 
 [testenv:fmt]
 description = Format the code
+deps =
+    black==22.8.0
+    isort==5.10.1
 commands =
     isort {[vars]src_path} {[vars]tests_path}
     black {[vars]src_path} {[vars]tests_path}
 
 [testenv:lint]
 description = Lint the code
+deps =
+    mypy
+    pylint
+    pydocstyle
+    pytest
+    black==22.8.0
+    codespell==2.2.1
+    flake8==5.0.4
+    flake8-builtins==1.5.3
+    flake8-copyright==0.2.3
+    flake8-docstrings==1.6.0
+    isort==5.10.1
+    pep8-naming==0.13.2
+    pyproject-flake8==5.0.4.post1
+    flake8-docstrings-complete>=1.0.3
+    flake8-test-docs>=1.0
 commands =
     pydocstyle {[vars]src_path}
     codespell {toxinidir} --skip {toxinidir}/.git --skip {toxinidir}/.tox \
@@ -63,6 +64,10 @@ commands =
 
 [testenv:unit]
 description = Run unit tests
+deps =
+    pytest
+    coverage[toml]
+    -r {tox_root}/requirements.txt
 commands =
     coverage run --source={[vars]src_path} \
                  -m pytest \
@@ -75,25 +80,31 @@ commands =
 
 [testenv:coverage-report]
 description = Create test coverage report
+deps =
+    coverage[toml]
+    pytest
+    -r{toxinidir}/requirements.txt
 commands =
     coverage report
 
 [testenv:static]
 description = Run static analysis tests
 deps =
-    {[testenv]deps}
     bandit[toml]
+    -r{toxinidir}/requirements.txt
 commands =
     bandit -c {toxinidir}/pyproject.toml -r {[vars]src_path} {[vars]tests_path}
 
 [testenv:integration]
 description = Run integration tests
 deps =
-    {[testenv]deps}
     ipdb==0.13.9
     juju==3.5.2.0
-    pytest-operator==0.40.0
-    pytest-asyncio==0.21.2
+    pytest==7.1.3
+    pytest-operator==0.35.0
+    temporalio==1.6.0
+    pytest-asyncio==0.21
+    -r{toxinidir}/requirements.txt
 allowlist_externals =
     sudo
     sysctl

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,24 @@ tests_path = {tox_root}/tests
 all_path = {[vars]src_path} {[vars]tests_path}
 
 [testenv]
+deps =
+    mypy==1.15.0
+    pylint==3.3.4
+    pydocstyle==6.3.0
+    pytest==8.3.4
+    black==22.8.0
+    isort==5.10.1
+    codespell==2.2.1
+    flake8>=7.0.0
+    flake8-builtins==2.5.0
+    flake8-copyright==0.2.4
+    flake8-docstrings==1.7.0
+    flake8-docstrings-complete==1.4.1
+    flake8-test-docs==1.0.8
+    pyproject-flake8==7.0.0
+    pep8-naming==0.14.1
+    coverage[toml]==7.6.12
+    -r {tox_root}/requirements.txt
 set_env =
     PYTHONPATH = {tox_root}/lib:{[vars]src_path}
     PYTHONBREAKPOINT=pdb.set_trace
@@ -25,31 +43,12 @@ pass_env =
 
 [testenv:fmt]
 description = Format the code
-deps =
-    black==22.8.0
-    isort==5.10.1
 commands =
     isort {[vars]src_path} {[vars]tests_path}
     black {[vars]src_path} {[vars]tests_path}
 
 [testenv:lint]
 description = Lint the code
-deps =
-    mypy
-    pylint
-    pydocstyle
-    pytest
-    black==22.8.0
-    codespell==2.2.1
-    flake8==5.0.4
-    flake8-builtins==1.5.3
-    flake8-copyright==0.2.3
-    flake8-docstrings==1.6.0
-    isort==5.10.1
-    pep8-naming==0.13.2
-    pyproject-flake8==5.0.4.post1
-    flake8-docstrings-complete>=1.0.3
-    flake8-test-docs>=1.0
 commands =
     pydocstyle {[vars]src_path}
     codespell {toxinidir} --skip {toxinidir}/.git --skip {toxinidir}/.tox \
@@ -64,10 +63,6 @@ commands =
 
 [testenv:unit]
 description = Run unit tests
-deps =
-    pytest
-    coverage[toml]
-    -r {tox_root}/requirements.txt
 commands =
     coverage run --source={[vars]src_path} \
                  -m pytest \
@@ -80,31 +75,25 @@ commands =
 
 [testenv:coverage-report]
 description = Create test coverage report
-deps =
-    coverage[toml]
-    pytest
-    -r{toxinidir}/requirements.txt
 commands =
     coverage report
 
 [testenv:static]
 description = Run static analysis tests
 deps =
+    {[testenv]deps}
     bandit[toml]
-    -r{toxinidir}/requirements.txt
 commands =
     bandit -c {toxinidir}/pyproject.toml -r {[vars]src_path} {[vars]tests_path}
 
 [testenv:integration]
 description = Run integration tests
 deps =
+    {[testenv]deps}
     ipdb==0.13.9
     juju==3.5.2.0
-    pytest==7.1.3
     pytest-operator==0.35.0
-    temporalio==1.6.0
     pytest-asyncio==0.21
-    -r{toxinidir}/requirements.txt
 allowlist_externals =
     sudo
     sysctl


### PR DESCRIPTION
## What
This PR does two things:
1. Re-configure `tox` environments for updated dependencies and unify dependencies.
2. No longer keep a flag for truststore initialization.

## Why
1. Move to Python3.12 broke the old versions of dependencies so they had to be updated, in multiple environments so I updated and unified them.
2. Truststores are `cacerts` inside containers. But if a container dies changes are lost. So keeping a flag does not work and the initialization is idempotent. There are multiple ways of handling this issue but I opted for the simplest one for now.