### PR TITLE
CSS-13826/13734 SSO/Ingress Changes

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Install LXD
         uses: canonical/setup-lxd@v0.1.1
         with:
-          channel: 6.1/stable
+          channel: 5.21/stable
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,10 +83,10 @@ Deploying Opensearch:
 ```shell
 juju switch lxd:datahub-vm
 # Less than 3 units might work for a while but is prone to blocking
-juju deploy opensearch --channel 2/edge -n 3
+juju deploy opensearch --channel 2/edge -n 2
 juju deploy self-signed-certificates
 juju deploy postgresql --channel 14/stable
-juju deploy kafka
+juju deploy kafka --channel 3/edge
 juju deploy zookeeper
 juju integrate opensearch self-signed-certificates
 juju integrate kafka zookeeper

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,12 +77,13 @@ juju model-config logging-config="<root>=INFO;unit=DEBUG"
 
 ## Deploy the dependencies
 
-DataHub has PostgreSQL, Kafka, and OpenSearch as dependencies. Opensearch only has a machine charm, while the others have both a machine and a Kubernetes charm. In production, all of the dependencies are intended to be deployed on machines but for simplification of development purposes you can have only Opensearch on a machine and deploy the rest on `microk8s`. So, the instructions here will cover that scenario.
+DataHub has PostgreSQL, Kafka, and OpenSearch as dependencies. Opensearch only has a machine charm, while the others have both a machine and a Kubernetes charm. However, the main deployment scenario is one where dependencies are deployed as machine charms. So, the documentation covers it.
 
-Deploying Opensearch:
+Deploying dependencies and creating offers:
 ```shell
 juju switch lxd:datahub-vm
-# Less than 3 units might work for a while but is prone to blocking
+# Opensearch charms needs a minimum of two units to cover 
+# the indexes created by DataHub
 juju deploy opensearch --channel 2/edge -n 2
 juju deploy self-signed-certificates
 juju deploy postgresql --channel 14/stable
@@ -95,7 +96,7 @@ juju offer postgresql:database pg-client
 juju offer kafka:kafka-client kafka-client
 ```
 
-Deploying other dependencies:
+Consuming offers:
 ```shell
 juju switch microk8s:datahub-k8s
 juju consume lxd:admin/datahub-vm.os-client os-client
@@ -157,6 +158,9 @@ juju deploy ./datahub-k8s_ubuntu-22.04-amd64.charm \
 --resource datahub-postgresql-setup=acryldata/datahub-postgres-setup:v0.13.3 \
 --resource datahub-upgrade=acryldata/datahub-upgrade:v0.13.3 \
 --config encryption-keys-secret-id=<secret-id>
+
+# Grant secret
+juju grant-secret <secret-name> datahub-k8s
 ```
 
 **Note:** The configuration variables need to be set at deployment time and they should not be changed afterwards. DataHub expects these secrets to be secure, so ensure you have a secret with sufficient entropy. Future updates will make QoL changes here to make this easier to manage.
@@ -171,7 +175,7 @@ juju integrate datahub-k8s os-client
 
 **Note:** It is highly recommended to wait between commands to let `juju status` show an `active-idle` status for the charm.
 
-After the final command, it will take some time for the `datahub-frontend` container to settle. Once it does, you can login on `localhost:9002` with `datahub` for both username and password. Refer to [below](#accessing-datahub-from-the-host-machine) on how to connect to a `datahub` deployment inside a `multipass` VM.
+After the final command, it will take some time for the `datahub-frontend` container to settle. Once it does, you can login on `localhost:9002` with `datahub` for the username and the password fetched as described in the [README](./README.md#deploying-datahub). Refer to [below](#accessing-datahub-from-the-host-machine) on how to connect to a `datahub` deployment inside a `multipass` VM.
 
 **Note:** If the Opensearch offer is blocked from the provider end, DataHub will load but some functionalities such as `Ingestion` will not load. This is best identified by the requests to `/graphql` returning a `500`.
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ juju relate datahub-k8s os-client
 
 # Get the address of DataHub
 juju status | grep "^datahub-k8s\s" | grep -P "10\.\d+\.\d+\.\d+" | awk '{print $6}'
+
+# Get the initial admin credentials
+# Username is 'datahub' by default
+# Auto-generated password can be get via the command below
+juju show-secret --reveal --format json $(juju list-secrets --format json | \
+    jq -r 'to_entries | map(select(.value.label=="datahub-init-pwd")) | .[0].key') | \
+    jq -r 'map(.content.Data.password) | .[0]'
 ```
 
 After relations are set and settled, you can access DataHub at its address with port `9002` from your browser.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ juju add-secret <secret-name> --file=/path/to/secret.yaml  # Copy the ID from th
 
 # Deploy
 juju deploy datahub-k8s --config encryption-key-secret-id=<secret-id>
+juju grant-secret <secret-name> datahub-k8s
 
 # Wait for the unit to settle
 juju status --watch 3s --color
@@ -92,7 +93,7 @@ juju status | grep "^datahub-k8s\s" | grep -P "10\.\d+\.\d+\.\d+" | awk '{print 
 
 # Get the initial admin credentials
 # Username is 'datahub' by default
-# Auto-generated password can be get via the command below
+# Auto-generated password can be retrieved via the command below
 juju show-secret --reveal --format json $(juju list-secrets --format json | \
     jq -r 'to_entries | map(select(.value.label=="datahub-init-pwd")) | .[0].key') | \
     jq -r 'map(.content.Data.password) | .[0]'
@@ -105,26 +106,26 @@ After relations are set and settled, you can access DataHub at its address with 
 DataHub supports authentication via SSO. In order to enable it in the charm follow the steps:
 
 1. Issue credentials from Google Cloud via its [dashboard](https://console.cloud.google.com/apis/credentials).
-1.1. On the linked page, click `Create Credentials` and choose `OAuth client ID`.
-1.2. In the next page, choose `Web application` as the type.
-1.3. Give it a name.
-1.4. Under `Authorized redirect URIs`, add a URI that ends with `/callback/oidc` and begins with the domain used to access the DataHub frontend. For local deployment the complete URI would look like `http://localhost:9002/callback/oidc`.
-1.5. Get the `Client ID` and the `Client secret`.
-1.6. Create a YAML file of the following format:
+2. On the linked page, click `Create Credentials` and choose `OAuth client ID`.
+3. In the next page, choose `Web application` as the type.
+4. Give it a name.
+5. Under `Authorized redirect URIs`, add a URI that ends with `/callback/oidc` and begins with the domain used to access the DataHub frontend. For local deployment the complete URI would look like `http://localhost:9002/callback/oidc`.
+6. Get the `Client ID` and the `Client secret`.
+7. Create a YAML file of the following format:
 ```yaml
 client-id: <client-id-value>
 client-secret: <client-secret-value>
 ```
-2. Create a Juju secret.
-2.1. Go into the Juju model where DataHub is (to be) deployed.
-2.2. Run `juju add-secret <secret-name> --file=/path/to/yaml` and copy the secret ID.
-2.3. Deploy DataHub with the added config variable `--config oidc-secret-id=<secret-id>`.
-2.4. Run `juju grant-secret <secret-name> datahub-k8s` to set permissions.
-2.5. Proceed with the relations.
-3. If your deployment is behind a HTTP proxy, set it on your Juju model via
+8. Create a Juju secret.
+9. Go into the Juju model where DataHub is (to be) deployed.
+10. Run `juju add-secret <secret-name> --file=/path/to/yaml` and copy the secret ID.
+11. Deploy DataHub with the added config variable `--config oidc-secret-id=<secret-id>`.
+12. Run `juju grant-secret <secret-name> datahub-k8s` to set permissions.
+13. Proceed with the relations.
+14. If your deployment is behind a HTTP proxy, set it on your Juju model via
 ```sh
-juju model-config juju-http-proxy=http://squid.internal:3128
-juju model-config juju-https-proxy=http://squid.internal:3128
+juju model-config juju-http-proxy=<http-proxy-address>
+juju model-config juju-https-proxy=<http-proxy-address>
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -114,6 +114,11 @@ client-secret: <client-secret-value>
 2.3. Deploy DataHub with the added config variable `--config oidc-secret-id=<secret-id>`.
 2.4. Run `juju grant-secret <secret-name> datahub-k8s` to set permissions.
 2.5. Proceed with the relations.
+3. If your deployment is behind a HTTP proxy, set it on your Juju model via
+```sh
+juju model-config juju-http-proxy=http://squid.internal:3128
+juju model-config juju-https-proxy=http://squid.internal:3128
+```
 
 ## Contributing
 This charm is still in active development. Please see the [Juju SDK docs](https://juju.is/docs/sdk) for guidelines on enhancements to this charm following best practice guidelines, and [CONTRIBUTING.md](CONTRIBUTING.md) for developer guidance.

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -73,8 +73,13 @@ requires:
     interface: opensearch_client
     limit: 1
 
-  nginx-route:
+  nginx-fe-route:
     interface: nginx-route
+    limit: 1
+
+  nginx-gms-route:
+    interface: nginx-route
+    limit: 1
 
 # (Optional) Configuration options for the charm
 # This config section defines charm config options, and populates the Configure
@@ -99,10 +104,18 @@ config:
       description: Prefix for the names of Opensearch indices created and used by DataHub.
       type: string
 
-    external-hostname:
+    external-fe-hostname:
       description: |
-        The DNS listing used for external connections.
-        Will default to the name of the deployed application.
+        The hostname used for external connections to the Frontend.
+        This will default to the name of the deployed application
+        with a `-frontend` suffix.
+      type: string
+
+    external-gms-hostname:
+      description: |
+        The hostname used for external connections to the GMS.
+        This will default to the name of the deployed application
+        with a `-gms` suffix.
       type: string
     
     tls-secret-name:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -110,6 +110,14 @@ config:
         Name of the k8s secret which contains the TLS certificate to be used by ingress.
       type: string
 
+    use-play-cache-session-store:
+      description: |
+        Use Play framework's cache as session store instead of OIDC cookies.
+        Use this option when response headers are too large for reverse proxy buffers.
+        Note that this option turns the frontend service stateful and it is currently
+        unsupported for horizontally scaled deployments.
+      type: boolean
+      default: false
 
 # The containers and resources metadata apply to Kubernetes charms only.
 # See https://juju.is/docs/sdk/metadata-reference for a checklist and guidance.

--- a/src/charm.py
+++ b/src/charm.py
@@ -5,6 +5,7 @@
 """Charm the application."""
 
 import logging
+import secrets
 from typing import Dict, List, Type, Union
 
 import ops
@@ -114,6 +115,9 @@ class DatahubK8SOperatorCharm(TypedCharmBase[CharmConfig]):
         super().__init__(framework)
         self._state = State(self.app, lambda: self.model.get_relation("peer"))
 
+        # Services
+        for service in SERVICES:
+            self.framework.observe(self.on[service.name].pebble_ready, self._on_pebble_ready)
         self.framework.observe(self.on.config_changed, self._on_config_changed)
         self.framework.observe(self.on.peer_relation_changed, self._on_peer_relation_changed)
         self.framework.observe(self.on.update_status, self._on_update_status)
@@ -143,10 +147,6 @@ class DatahubK8SOperatorCharm(TypedCharmBase[CharmConfig]):
         # Ingress
         self._require_nginx_route()
 
-        # Services
-        for service in SERVICES:
-            self.framework.observe(self.on[service.name].pebble_ready, self._on_pebble_ready)
-
     @property
     def external_fe_hostname(self):
         """Return the hostname used for external connections to the frontend."""
@@ -156,28 +156,6 @@ class DatahubK8SOperatorCharm(TypedCharmBase[CharmConfig]):
     def external_gms_hostname(self):
         """Return the hostname used for external connections to the GMS."""
         return self.config["external-gms-hostname"] or f"{self.app.name}-gms"
-
-    def _require_nginx_route(self):
-        """Require nginx-route relation based on the current configuration."""
-        require_nginx_route(
-            charm=self,
-            service_hostname=self.external_fe_hostname,
-            service_name=self.app.name,
-            service_port=literals.FRONTEND_PORT,
-            tls_secret_name=self.config["tls-secret-name"] or "",
-            backend_protocol="HTTP",
-            nginx_route_relation_name="nginx-fe-route",
-        )
-
-        require_nginx_route(
-            charm=self,
-            service_hostname=self.external_gms_hostname,
-            service_name=self.app.name,
-            service_port=literals.GMS_PORT,
-            tls_secret_name=self.config["tls-secret-name"] or "",
-            backend_protocol="HTTP",
-            nginx_route_relation_name="nginx-gms-route",
-        )
 
     @log_event_handler(logger)
     def _on_pebble_ready(self, event: ops.PebbleReadyEvent):
@@ -197,10 +175,14 @@ class DatahubK8SOperatorCharm(TypedCharmBase[CharmConfig]):
         # Frontend service requires a file to be present at startup.
         if event.workload.name == services.FrontendService.name:
             self._state.frontend_truststore_initialized = False
-            # TODO (mertalpt): Seek to make the default user configurable.
+            password = self._generated_password()
+            if not password:
+                logger.info("could not generate admin password, will defer frontend initialization")
+                event.defer()
+            logger.debug("initial admin password generation successful")
             utils.push_contents_to_file(
                 event.workload,
-                "datahub:datahub",
+                f"datahub:{password}",
                 "/etc/datahub/plugins/frontend/auth/user.props",
                 0o644,
             )
@@ -336,6 +318,51 @@ class DatahubK8SOperatorCharm(TypedCharmBase[CharmConfig]):
             missing_relations = [k for (k, v) in relations.items() if v]
             err = f"missing required relation(s): {', '.join(missing_relations)}"
             raise exceptions.UnreadyStateError(err)
+
+    # Ref: https://github.com/jnsgruk/zinc-k8s-operator/blob/b1d5d9b19628480e2f8c3774d055b966fbb9e7ab/src/charm.py#L78  # noqa
+    def _generated_password(self):
+        """Report the generated admin passport; generate one if it does not exist."""
+        # If the peer relation is not ready, just return an empty string
+        relation = self.model.get_relation("peer")
+        if not relation:
+            return ""
+
+        # If the secret already exists, grab its content and return it
+        secret_id = relation.data[self.app].get("initial-admin-password", None)
+        if secret_id:
+            secret = self.model.get_secret(id=secret_id)
+            return secret.peek_content().get("password")
+
+        if self.unit.is_leader():
+            content = {"password": secrets.token_urlsafe(24)}
+            secret = self.app.add_secret(content, label=literals.INIT_PWD_SECRET_LABEL)
+            # Store the secret id in the peer relation for other units if required
+            relation.data[self.app]["initial-admin-password"] = secret.id
+            return content["password"]
+        else:
+            return ""
+
+    def _require_nginx_route(self):
+        """Require nginx-route relation based on the current configuration."""
+        require_nginx_route(
+            charm=self,
+            service_hostname=self.external_fe_hostname,
+            service_name=self.app.name,
+            service_port=literals.FRONTEND_PORT,
+            tls_secret_name=self.config["tls-secret-name"] or "",
+            backend_protocol="HTTP",
+            nginx_route_relation_name="nginx-fe-route",
+        )
+
+        require_nginx_route(
+            charm=self,
+            service_hostname=self.external_gms_hostname,
+            service_name=self.app.name,
+            service_port=literals.GMS_PORT,
+            tls_secret_name=self.config["tls-secret-name"] or "",
+            backend_protocol="HTTP",
+            nginx_route_relation_name="nginx-gms-route",
+        )
 
     def _update(self, event):
         """Update the DataHub configuration and replan its execution.

--- a/src/charm.py
+++ b/src/charm.py
@@ -339,8 +339,8 @@ class DatahubK8SOperatorCharm(TypedCharmBase[CharmConfig]):
             # Store the secret id in the peer relation for other units if required
             relation.data[self.app]["initial-admin-password"] = secret.id
             return content["password"]
-        else:
-            return ""
+
+        return ""
 
     def _require_nginx_route(self):
         """Require nginx-route relation based on the current configuration."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -253,7 +253,7 @@ class DatahubK8SOperatorCharm(TypedCharmBase[CharmConfig]):
                 plan = container.get_plan()
                 expected_plan = get_pebble_layer(service, context)
                 if plan != expected_plan:
-                    logger.info("invalid plan (out of sync) for '%s", service.name)
+                    logger.info("invalid plan (out of sync) for '%s'", service.name)
                     is_invalid = True
                     break  # guaranteed replan, exit loop
             if check.status != CheckStatus.UP:

--- a/src/charm.py
+++ b/src/charm.py
@@ -59,8 +59,7 @@ def get_pebble_layer(service: services.AbstractService, context: services.Servic
         "startup": "enabled" if service.is_enabled(context) else "disabled",
         "override": "replace",
     }
-    layer = {
-        "summary": f"DataHub layer for '{service.name}'",
+    layer: Dict = {
         "services": {
             service.name: svc_dict,
         },
@@ -82,6 +81,7 @@ def get_pebble_layer(service: services.AbstractService, context: services.Servic
                     "up": {
                         "override": "replace",
                         "period": "10s",
+                        "threshold": 3,
                         "http": {
                             "url": f"http://localhost:{service.healthcheck['port']}{service.healthcheck['endpoint']}"
                         },
@@ -99,7 +99,8 @@ class DatahubK8SOperatorCharm(TypedCharmBase[CharmConfig]):
     Attributes:
         _state: Used to store persistent data between invocations.
         config_type: Class used to store the config.
-        external_hostname: Property for the hostname of the unit visible to outside.
+        external_fe_hostname: Property for the hostname of the frontend visible to outside.
+        external_gms_hostname: Property for the hostname of the GMS visible to outside.
     """
 
     config_type = CharmConfig
@@ -147,19 +148,35 @@ class DatahubK8SOperatorCharm(TypedCharmBase[CharmConfig]):
             self.framework.observe(self.on[service.name].pebble_ready, self._on_pebble_ready)
 
     @property
-    def external_hostname(self):
-        """Return the DNS listing used for external connections."""
-        return self.config["external-hostname"] or self.app.name
+    def external_fe_hostname(self):
+        """Return the hostname used for external connections to the frontend."""
+        return self.config["external-fe-hostname"] or f"{self.app.name}-frontend"
+
+    @property
+    def external_gms_hostname(self):
+        """Return the hostname used for external connections to the GMS."""
+        return self.config["external-gms-hostname"] or f"{self.app.name}-gms"
 
     def _require_nginx_route(self):
         """Require nginx-route relation based on the current configuration."""
         require_nginx_route(
             charm=self,
-            service_hostname=self.external_hostname,
+            service_hostname=self.external_fe_hostname,
             service_name=self.app.name,
             service_port=literals.FRONTEND_PORT,
             tls_secret_name=self.config["tls-secret-name"] or "",
             backend_protocol="HTTP",
+            nginx_route_relation_name="nginx-fe-route",
+        )
+
+        require_nginx_route(
+            charm=self,
+            service_hostname=self.external_gms_hostname,
+            service_name=self.app.name,
+            service_port=literals.GMS_PORT,
+            tls_secret_name=self.config["tls-secret-name"] or "",
+            backend_protocol="HTTP",
+            nginx_route_relation_name="nginx-gms-route",
         )
 
     @log_event_handler(logger)
@@ -250,9 +267,10 @@ class DatahubK8SOperatorCharm(TypedCharmBase[CharmConfig]):
                 is_invalid = True
                 break  # guaranteed replan, exit loop
             else:
-                plan = container.get_plan()
+                plan = container.get_plan().to_dict()
                 expected_plan = get_pebble_layer(service, context)
-                if plan != expected_plan:
+                # `get_plan` returns a `dict` subclass that messes with comparison.
+                if dict(plan) != expected_plan:
                     logger.info("invalid plan (out of sync) for '%s'", service.name)
                     is_invalid = True
                     break  # guaranteed replan, exit loop
@@ -335,7 +353,7 @@ class DatahubK8SOperatorCharm(TypedCharmBase[CharmConfig]):
             return
 
         # Set ports.
-        self.model.unit.set_ports(literals.FRONTEND_PORT)
+        self.model.unit.set_ports(literals.FRONTEND_PORT, literals.GMS_PORT)
 
         context = services.ServiceContext(self)
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -328,7 +328,7 @@ class DatahubK8SOperatorCharm(TypedCharmBase[CharmConfig]):
             return ""
 
         # If the secret already exists, grab its content and return it
-        secret_id = relation.data[self.app].get("initial-admin-password", None)
+        secret_id = relation.data[self.app].get(literals.INIT_PWD_SECRET_LABEL, None)
         if secret_id:
             secret = self.model.get_secret(id=secret_id)
             return secret.peek_content().get("password")
@@ -337,13 +337,14 @@ class DatahubK8SOperatorCharm(TypedCharmBase[CharmConfig]):
             content = {"password": secrets.token_urlsafe(24)}
             secret = self.app.add_secret(content, label=literals.INIT_PWD_SECRET_LABEL)
             # Store the secret id in the peer relation for other units if required
-            relation.data[self.app]["initial-admin-password"] = secret.id
+            relation.data[self.app][literals.INIT_PWD_SECRET_LABEL] = secret.id
             return content["password"]
 
         return ""
 
     def _require_nginx_route(self):
         """Require nginx-route relation based on the current configuration."""
+        # TODO (mertalpt): Ensure `tls_secret_name` functionality works or remove it entirely.
         require_nginx_route(
             charm=self,
             service_hostname=self.external_fe_hostname,

--- a/src/literals.py
+++ b/src/literals.py
@@ -9,7 +9,7 @@ PLACEHOLDER_TOPIC = "datahub_topic"
 FRONTEND_PORT = 9002
 GMS_PORT = 8080
 
-INIT_PWD_SECRET_LABEL = "datahub-init-pwd"
+INIT_PWD_SECRET_LABEL = "datahub-init-pwd"  # nosec
 
 RUNNER_SRC_PATH = ("src", "scripts", "runner.sh")
 RUNNER_DEST_PATH = "/charm-external/runner.sh"

--- a/src/literals.py
+++ b/src/literals.py
@@ -7,6 +7,7 @@ DB_NAME = "datahub_db"
 PLACEHOLDER_INDEX = "datahub_index"
 PLACEHOLDER_TOPIC = "datahub_topic"
 FRONTEND_PORT = 9002
+GMS_PORT = 8080
 
 RUNNER_SRC_PATH = ("src", "scripts", "runner.sh")
 RUNNER_DEST_PATH = "/charm-external/runner.sh"

--- a/src/literals.py
+++ b/src/literals.py
@@ -9,6 +9,8 @@ PLACEHOLDER_TOPIC = "datahub_topic"
 FRONTEND_PORT = 9002
 GMS_PORT = 8080
 
+INIT_PWD_SECRET_LABEL = "datahub-init-pwd"
+
 RUNNER_SRC_PATH = ("src", "scripts", "runner.sh")
 RUNNER_DEST_PATH = "/charm-external/runner.sh"
 TRUSTSTORE_INIT_SCRIPT_SRC_PATH = ("src", "scripts", "init-truststore.sh")

--- a/src/services.py
+++ b/src/services.py
@@ -340,11 +340,9 @@ class FrontendService(AbstractService):
             https_proxy = urlparse(https_proxy_raw)
             proxy_vars["HTTPS_PROXY_HOST"] = https_proxy.hostname
             proxy_vars["HTTPS_PROXY_PORT"] = str(https_proxy.port or "")
-        if no_proxy_raw := os.getenv("JUJU_CHARM_NO_PROXY"):
-            no_proxy = no_proxy_raw.split(",")
-            no_proxy_hosts = no_proxy_hosts.union(no_proxy)
-            proxy_vars["HTTP_NON_PROXY_HOSTS"] = "|".join(no_proxy_hosts)
 
+        # TODO (mertalpt): Figure out a way to integrate model no proxy hosts into the charm.
+        proxy_vars["HTTP_NON_PROXY_HOSTS"] = "|".join(no_proxy_hosts)
         env.update(proxy_vars)
 
         # Set up OIDC if needed.

--- a/src/services.py
+++ b/src/services.py
@@ -316,6 +316,9 @@ class FrontendService(AbstractService):
             "ELASTIC_CLIENT_USERNAME": os_conn["username"],
             "ELASTIC_CLIENT_PASSWORD": os_conn["password"],
             "AUTH_SESSION_TTL_HOURS": "24",
+            # TODO (mertalpt): Consider making this a config option.
+            # Required for access tokens, i.e. service accounts.
+            "METADATA_SERVICE_AUTH_ENABLED": "true",
         }
         # Ref: https://datahubproject.io/docs/troubleshooting/quickstart/#ive-configured-oidc-but-i-cannot-login-i-get-continuously-redirected-what-do-i-do  # noqa
         if context.charm.config.use_play_cache_session_store:
@@ -358,10 +361,10 @@ class FrontendService(AbstractService):
             raise exceptions.ImproperSecretError("secret pointed to by 'oidc-secret-id' has improper contents")
 
         oidc_base_url = "http://localhost:9002"
-        if context.charm.config.external_hostname:
+        if context.charm.config.external_fe_hostname:
             # OIDC mandates the use of TLS, so the protocol is correct.
             # TODO (mertalpt): Add a check when OIDC is enabled without TLS.
-            oidc_base_url = f"https://{context.charm.config.external_hostname}"
+            oidc_base_url = f"https://{context.charm.config.external_fe_hostname}"
 
         oidc_env = {
             "AUTH_OIDC_ENABLED": "true",
@@ -558,6 +561,9 @@ class GMSService(AbstractService):
             "ALWAYS_EMIT_CHANGE_LOG": "false",
             "GRAPH_SERVICE_DIFF_MODE_ENABLED": "true",
             "GRAPHQL_QUERY_INTROSPECTION_ENABLED": "true",
+            # TODO (mertalpt): Consider making this a config option.
+            # Required for access tokens, i.e. service accounts.
+            "METADATA_SERVICE_AUTH_ENABLED": "true",
         }
         if context.charm.config.opensearch_index_prefix:
             env["INDEX_PREFIX"] = context.charm.config.opensearch_index_prefix
@@ -1116,7 +1122,7 @@ class UpgradeService(AbstractService):
         # In order to fit the pattern of services, we loosen the semantics.
         # The "initialization" for 'Upgrade' actually runs an upgrade for the whole ecosystem.
         if context.charm._state.ran_upgrade:
-            logger.info("Already ran datahub-upgrade, skipping initialization")
+            logger.debug("Already ran datahub-upgrade, skipping initialization")
             return False
 
         # We need to ensure that the truststore is configured first.

--- a/src/structured_config.py
+++ b/src/structured_config.py
@@ -17,6 +17,8 @@ class CharmConfig(BaseConfigModel):
 
     Attributes:
         encryption_keys_secret_id: Juju secret ID to use for secret keys.
+        use_play_cache_session_store: Flag to determine if Play cache will be used for
+            session store instead of having browser based OIDC cookies.
         oidc_secret_id: Juju secret ID to enable SSO.
         kafka_topic_prefix: Prefix to use for Kafka topic names.
         opensearch_index_prefix: Prefix to use for Opensearch indexes.
@@ -25,6 +27,7 @@ class CharmConfig(BaseConfigModel):
     """
 
     encryption_keys_secret_id: str
+    use_play_cache_session_store: bool
     oidc_secret_id: Optional[str] = None
     kafka_topic_prefix: Optional[str] = None
     opensearch_index_prefix: Optional[str] = None

--- a/src/structured_config.py
+++ b/src/structured_config.py
@@ -22,7 +22,8 @@ class CharmConfig(BaseConfigModel):
         oidc_secret_id: Juju secret ID to enable SSO.
         kafka_topic_prefix: Prefix to use for Kafka topic names.
         opensearch_index_prefix: Prefix to use for Opensearch indexes.
-        external_hostname: Hostname of unit visible to outside.
+        external_fe_hostname: Hostname of frontend visible to outside.
+        external_gms_hostname: Hostname of GMS visible to outside.
         tls_secret_name: Name of the k8s secret to use for the TLS certificate.
     """
 
@@ -31,7 +32,8 @@ class CharmConfig(BaseConfigModel):
     oidc_secret_id: Optional[str] = None
     kafka_topic_prefix: Optional[str] = None
     opensearch_index_prefix: Optional[str] = None
-    external_hostname: Optional[str] = None
+    external_fe_hostname: Optional[str] = None
+    external_gms_hostname: Optional[str] = None
     tls_secret_name: Optional[str] = None
 
     @field_validator("*", mode="before")

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -97,7 +97,7 @@ async def deploy_charm(ops_test: OpsTest, charm: Path) -> None:
         raise_on_blocked=False,
         timeout=200,
     )
-    await ops_test.model.integrate(APP_NAME, INGRESS_NAME)
+    await ops_test.model.integrate(f"{APP_NAME}:nginx-fe-route", INGRESS_NAME)
     await ops_test.model.wait_for_idle(
         apps=[INGRESS_NAME],
         status="active",

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -50,7 +50,7 @@ class TestDeployment:
                 logger.info("Deploying LXD dependencies")
                 await asyncio.gather(
                     ops_test.model.deploy(helpers.KAFKA_NAME, channel=helpers.KAFKA_CHANNEL),
-                    ops_test.model.deploy(helpers.OPENSEARCH_NAME, channel=helpers.OPENSEARCH_CHANNEL, num_units=3),
+                    ops_test.model.deploy(helpers.OPENSEARCH_NAME, channel=helpers.OPENSEARCH_CHANNEL, num_units=2),
                     ops_test.model.deploy(helpers.POSTGRES_NAME, channel=helpers.POSTGRES_CHANNEL),
                     ops_test.model.deploy(helpers.CERTIFICATES_NAME, channel=helpers.CERTIFICATES_CHANNEL),
                     ops_test.model.deploy(helpers.ZOOKEPER_NAME, channel=helpers.ZOOKEEPER_CHANNEL),

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -70,8 +70,8 @@ async def _get_password() -> str:  # noqa C901
         logger.info("Found the password secret with id: '%s'", name)
     except StopIteration as e:
         logger.error(
-            "Error searching the password secret with id: '%s'\nError was: '%s'\nSecrets were: %s",
-            name,
+            "Error searching the password secret with label: '%s'\nError was: '%s'\nSecrets were: %s",
+            literals.INIT_PWD_SECRET_LABEL,
             str(e),
             secrets,
         )

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -21,8 +21,11 @@ import literals
 logger = logging.getLogger(__name__)
 
 
-async def _get_password() -> str:  # noqa C901
+async def _get_password(model_name: str) -> str:  # noqa C901
     """Get admin password from the Juju secret.
+
+    Args:
+        model_name: Name of the model to get the password secret from.
 
     Raises:
         CalledProcessError: If command executions fail.
@@ -34,6 +37,8 @@ async def _get_password() -> str:  # noqa C901
         cmd = [
             "/snap/bin/juju",
             "list-secrets",
+            "--model",
+            model_name,
             "--format",
             "json",
         ]
@@ -82,6 +87,8 @@ async def _get_password() -> str:  # noqa C901
             "/snap/bin/juju",
             "show-secret",
             name,
+            "--model",
+            model_name,
             "--format",
             "json",
             "--reveal",
@@ -297,7 +304,7 @@ class TestDeployment:
             base_url = await helpers.get_unit_url(ops_test, helpers.APP_NAME, 0, 9002)
 
             logger.info("Fetching admin password")
-            admin_pwd = await _get_password()
+            admin_pwd = await _get_password(k8s_model)
 
             with requests.session() as s:
                 # Log in


### PR DESCRIPTION
## Reason for Changes
Google OIDC SSO did not function on a Prodstack deployment. Upon investigation, the issue was about proxy and ingress configurations that were not reflected in the charm code.

The other part of the PR is to add an ingress route for GMS itself to enable services to run against DataHub.

## Changes
- Support for HTTP/S proxy variables for the frontend were added via Juju model.
- OIDC cookies can exceed ingress buffer size, added a configuration option for server side session store that remedies it for certain scenarios.
- Updated `update_status` handler to check for out of sync plans as there is no hook to listen for model config changes.
- Added an ingress route for GMS.
- Updated Nginx relations and related config options.
- Enabled issuing access tokens.
- Initial admin password is now randomly generated as a Juju secret instead of the default. Which was a security vulnerability because you cannot change it post-deployment (without manual DB operations).