### PR TITLE
Fix Password Bug

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+## Description
+
+The what and why - include a summary of the change, describe what it does, and include relevant motivation and context.
+
+Fixes _JIRA/GitHub issue number_
+
+## Engineering checklist
+_Check only items that apply_
+
+- [ ] Documentation updated
+- [ ] Covered by unit tests
+- [ ] Covered by integration tests
+- [ ] Independent change*
+
+ _* This is an independent change if it can be merged and released independently without any related service deployments._
+
+## Merging instructions
+
+The preferred way of merging:
+- [ ] Merge
+- [ ] Squash and Merge
+- [ ] Rebase and Merge
+
+## Test instructions
+
+_(optional)_ Describe any non-standard test instructions and configuration settings. Delete this section if not applicable.
+
+## Notes for code reviewers
+
+_(optional)_ Mention any relevant information for code reviewers. Delete this section if not applicable.

--- a/src/charm.py
+++ b/src/charm.py
@@ -183,7 +183,7 @@ class DatahubK8SOperatorCharm(TypedCharmBase[CharmConfig]):
             utils.push_contents_to_file(
                 event.workload,
                 f"datahub:{password}",
-                "/etc/datahub/plugins/frontend/auth/user.props",
+                "/datahub-frontend/conf/user.props",
                 0o644,
             )
         if event.workload.name == services.GMSService.name:


### PR DESCRIPTION
## Description of Changes

For some reason, DataHub has two files to manually register users and both of them are valid. The PR changes where the updated file is pushed to match the [official documentation](https://datahubproject.io/docs/authentication/changing-default-credentials/).

Also, a PR template is added. Though, it did not activate for this particular PR, maybe GitHub does not pick it up for incoming changes.