### PR TITLE
Add verbose logging config

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -53,3 +53,7 @@ jobs:
       - name: Dump logs
         if: failure()
         uses: canonical/charming-actions/dump-logs@main
+
+      - name: Setup tmate session
+        if: ${{ failure() }}
+        uses: canonical/action-tmate@main

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -88,6 +88,13 @@ requires:
 # General configuration documentation: https://juju.is/docs/sdk/config
 config:
   options:
+    auth-verbose-logging:
+      description: |
+        Enable verbose authentication logging. 
+        Enabling this will leak sensisitve information in the logs. 
+        Disable when finished debugging.
+      type: boolean
+      default: false
     encryption-keys-secret-id:
       description: Juju secret ID for the Frontand and GMS encryption keys.
       type: string

--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -16,7 +16,7 @@ r"""Library to manage the relation for the data-platform products.
 
 This library contains the Requires and Provides classes for handling the relation
 between an application and multiple managed application supported by the data-team:
-MySQL, Postgresql, MongoDB, Redis, and Kafka.
+MySQL, Postgresql, MongoDB, Redis, Kafka, and Karapace.
 
 ### Database (MySQL, Postgresql, MongoDB, and Redis)
 
@@ -34,6 +34,7 @@ application charm code:
 from charms.data_platform_libs.v0.data_interfaces import (
     DatabaseCreatedEvent,
     DatabaseRequires,
+    DatabaseEntityCreatedEvent,
 )
 
 class ApplicationCharm(CharmBase):
@@ -45,6 +46,7 @@ class ApplicationCharm(CharmBase):
         # Charm events defined in the database requires charm library.
         self.database = DatabaseRequires(self, relation_name="database", database_name="database")
         self.framework.observe(self.database.on.database_created, self._on_database_created)
+        self.framework.observe(self.database.on.database_entity_created, self._on_database_entity_created)
 
     def _on_database_created(self, event: DatabaseCreatedEvent) -> None:
         # Handle the created database
@@ -61,12 +63,17 @@ class ApplicationCharm(CharmBase):
 
         # Set active status
         self.unit.status = ActiveStatus("received database credentials")
+
+    def _on_database_entity_created(self, event: DatabaseEntityCreatedEvent) -> None:
+        # Handle the created entity
+        ...
 ```
 
 As shown above, the library provides some custom events to handle specific situations,
 which are listed below:
 
 -  database_created: event emitted when the requested database is created.
+-  database_entity_created: event emitted when the requested entity is created.
 -  endpoints_changed: event emitted when the read/write endpoints of the database have changed.
 -  read_only_endpoints_changed: event emitted when the read-only endpoints of the database
   have changed. Event is not triggered if read/write endpoints changed too.
@@ -141,7 +148,6 @@ class ApplicationCharm(CharmBase):
             event.endpoints,
         )
         ...
-
 ```
 
 When it's needed to check whether a plugin (extension) is enabled on the PostgreSQL
@@ -154,7 +160,6 @@ parts:
   charm:
     charm-binary-python-packages:
       - psycopg[binary]
-
 ```
 
 ### Provider Charm
@@ -187,6 +192,7 @@ class SampleCharm(CharmBase):
         self.provided_database.set_credentials(event.relation.id, username, password)
         # set other variables for the relation event.set_tls("False")
 ```
+
 As shown above, the library provides a custom event (database_requested) to handle
 the situation when an application charm requests a new database to be created.
 It's preferred to subscribe to this event instead of relation changed event to avoid
@@ -207,6 +213,7 @@ from charms.data_platform_libs.v0.data_interfaces import (
     BootstrapServerChangedEvent,
     KafkaRequires,
     TopicCreatedEvent,
+    TopicEntityCreatedEvent,
 )
 
 class ApplicationCharm(CharmBase):
@@ -219,6 +226,9 @@ class ApplicationCharm(CharmBase):
         )
         self.framework.observe(
             self.kafka.on.topic_created, self._on_kafka_topic_created
+        )
+        self.framework.observe(
+            self.kafka.on.topic_entity_created, self._on_kafka_topic_entity_created
         )
 
     def _on_kafka_bootstrap_server_changed(self, event: BootstrapServerChangedEvent):
@@ -238,6 +248,9 @@ class ApplicationCharm(CharmBase):
         zookeeper_uris = event.zookeeper_uris
         ...
 
+    def _on_kafka_topic_entity_created(self, event: TopicEntityCreatedEvent):
+        # Event triggered when an entity was created for this application
+        ...
 ```
 
 As shown above, the library provides some custom events to handle specific situations,
@@ -268,6 +281,7 @@ from charms.data_platform_libs.v0.data_interfaces import (
         # Charm events defined in the Kafka Provides charm library.
         self.kafka_provider = KafkaProvides(self, relation_name="kafka_client")
         self.framework.observe(self.kafka_provider.on.topic_requested, self._on_topic_requested)
+        self.framework.observe(self.kafka_provider.on.topic_entity_requested, self._on_entity_requested)
         # Kafka generic helper
         self.kafka = KafkaHelper()
 
@@ -283,11 +297,113 @@ from charms.data_platform_libs.v0.data_interfaces import (
         self.kafka_provider.set_tls(relation_id, "False")
         self.kafka_provider.set_zookeeper_uris(relation_id, ...)
 
+    def _on_entity_requested(self, event: EntityRequestedEvent):
+        # Handle the on_topic_entity_requested event.
+        ...
 ```
 As shown above, the library provides a custom event (topic_requested) to handle
 the situation when an application charm requests a new topic to be created.
 It is preferred to subscribe to this event instead of relation changed event to avoid
 creating a new topic when other information other than a topic name is
+exchanged in the relation databag.
+
+### Karapace
+
+This library is the interface to use and interact with the Karapace charm. This library contains
+custom events that add convenience to manage Karapace, and provides methods to consume the
+application related data.
+
+#### Requirer Charm
+
+```python
+
+from charms.data_platform_libs.v0.data_interfaces import (
+    EndpointsChangedEvent,
+    KarapaceRequires,
+    SubjectAllowedEvent,
+)
+
+class ApplicationCharm(CharmBase):
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.karapace = KarapaceRequires(self, relation_name="karapace_client", subject="test-subject")
+        self.framework.observe(
+            self.karapace.on.server_changed, self._on_karapace_server_changed
+        )
+        self.framework.observe(
+            self.karapace.on.subject_allowed, self._on_karapace_subject_allowed
+        )
+        self.framework.observe(
+            self.karapace.on.subject_entity_created, self._on_subject_entity_created
+        )
+
+
+    def _on_karapace_server_changed(self, event: EndpointsChangedEvent):
+        # Event triggered when a server endpoint was changed for this application
+        new_server = event.endpoints
+        ...
+
+    def _on_karapace_subject_allowed(self, event: SubjectAllowedEvent):
+        # Event triggered when a subject was allowed for this application
+        username = event.username
+        password = event.password
+        tls = event.tls
+        endpoints = event.endpoints
+        ...
+
+    def _on_subject_entity_created(self, event: SubjectEntityCreatedEvent):
+        # Event triggered when a subject entity was created this application
+        entity_name = event.entity_name
+        entity_password = event.entity_password
+        ...
+```
+
+As shown above, the library provides some custom events to handle specific situations,
+which are listed below:
+
+- subject_allowed: event emitted when the requested subject is allowed.
+- server_changed: event emitted when the server endpoints have changed.
+
+#### Provider Charm
+
+Following the previous example, this is an example of the provider charm.
+
+```python
+class SampleCharm(CharmBase):
+
+from charms.data_platform_libs.v0.data_interfaces import (
+    KarapaceProvides,
+    SubjectRequestedEvent,
+)
+
+    def __init__(self, *args):
+        super().__init__(*args)
+
+        # Default charm events.
+        self.framework.observe(self.on.start, self._on_start)
+
+        # Charm events defined in the Karapace Provides charm library.
+        self.karapace_provider = KarapaceProvides(self, relation_name="karapace_client")
+        self.framework.observe(self.karapace_provider.on.subject_requested, self._on_subject_requested)
+        # Karapace generic helper
+        self.karapace = KarapaceHelper()
+
+    def _on_subject_requested(self, event: SubjectRequestedEvent):
+        # Handle the on_subject_requested event.
+
+        subject = event.subject
+        relation_id = event.relation.id
+        # set connection info in the databag relation
+        self.karapace_provider.set_endpoint(relation_id, self.karapace.get_endpoint())
+        self.karapace_provider.set_credentials(relation_id, username=username, password=password)
+        self.karapace_provider.set_tls(relation_id, "False")
+```
+
+As shown above, the library provides a custom event (subject_requested) to handle
+the situation when an application charm requests a new subject to be created.
+It is preferred to subscribe to this event instead of relation changed event to avoid
+creating a new subject when other information other than a subject name is
 exchanged in the relation databag.
 """
 
@@ -331,7 +447,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 42
+LIBPATCH = 52
 
 PYDEPS = ["ops>=2.0.0"]
 
@@ -349,8 +465,11 @@ added - keys that were added
 changed - keys that still exist but have new values
 deleted - key that were deleted"""
 
+ENTITY_USER = "USER"
+ENTITY_GROUP = "GROUP"
 
 PROV_SECRET_PREFIX = "secret-"
+PROV_SECRET_FIELDS = "provided-secrets"
 REQ_SECRET_FIELDS = "requested-secrets"
 GROUP_MAPPING_FIELD = "secret_group_mapping"
 GROUP_SEPARATOR = "@"
@@ -585,6 +704,8 @@ class SecretGroupsAggregate(str):
     def __init__(self):
         self.USER = SecretGroup("user")
         self.TLS = SecretGroup("tls")
+        self.MTLS = SecretGroup("mtls")
+        self.ENTITY = SecretGroup("entity")
         self.EXTRA = SecretGroup("extra")
 
     def __setattr__(self, name, value):
@@ -951,7 +1072,7 @@ class DataDict(UserDict):
 
 
 class Data(ABC):
-    """Base relation data mainpulation (abstract) class."""
+    """Base relation data manipulation (abstract) class."""
 
     SCOPE = Scope.APP
 
@@ -963,7 +1084,12 @@ class Data(ABC):
         "read-only-uris": SECRET_GROUPS.USER,
         "tls": SECRET_GROUPS.TLS,
         "tls-ca": SECRET_GROUPS.TLS,
+        "mtls-cert": SECRET_GROUPS.MTLS,
+        "entity-name": SECRET_GROUPS.ENTITY,
+        "entity-password": SECRET_GROUPS.ENTITY,
     }
+
+    SECRET_FIELDS = []
 
     def __init__(
         self,
@@ -978,15 +1104,13 @@ class Data(ABC):
         self.component = self.local_app if self.SCOPE == Scope.APP else self.local_unit
         self.secrets = SecretCache(self._model, self.component)
         self.data_component = None
+        self._local_secret_fields = []
+        self._remote_secret_fields = list(self.SECRET_FIELDS)
 
     @property
     def relations(self) -> List[Relation]:
         """The list of Relation instances associated with this relation_name."""
-        return [
-            relation
-            for relation in self._model.relations[self.relation_name]
-            if self._is_relation_active(relation)
-        ]
+        return self._model.relations[self.relation_name]
 
     @property
     def secrets_enabled(self):
@@ -1000,38 +1124,250 @@ class Data(ABC):
         """Exposing secret-label map via a property -- could be overridden in descendants!"""
         return self.SECRET_LABEL_MAP
 
+    @property
+    def local_secret_fields(self) -> Optional[List[str]]:
+        """Local access to secrets field, in case they are being used."""
+        if self.secrets_enabled:
+            return self._local_secret_fields
+
+    @property
+    def remote_secret_fields(self) -> Optional[List[str]]:
+        """Local access to secrets field, in case they are being used."""
+        if self.secrets_enabled:
+            return self._remote_secret_fields
+
+    @property
+    def my_secret_groups(self) -> Optional[List[SecretGroup]]:
+        """Local access to secrets field, in case they are being used."""
+        if self.secrets_enabled:
+            return [
+                self.SECRET_LABEL_MAP[field]
+                for field in self._local_secret_fields
+                if field in self.SECRET_LABEL_MAP
+            ]
+
     # Mandatory overrides for internal/helper methods
 
-    @abstractmethod
+    @juju_secrets_only
     def _get_relation_secret(
         self, relation_id: int, group_mapping: SecretGroup, relation_name: Optional[str] = None
     ) -> Optional[CachedSecret]:
         """Retrieve a Juju Secret that's been stored in the relation databag."""
+        if not relation_name:
+            relation_name = self.relation_name
+
+        label = self._generate_secret_label(relation_name, relation_id, group_mapping)
+        if secret := self.secrets.get(label):
+            return secret
+
+        relation = self._model.get_relation(relation_name, relation_id)
+        if not relation:
+            return
+
+        if secret_uri := self.get_secret_uri(relation, group_mapping):
+            return self.secrets.get(label, secret_uri)
+
+    # Mandatory overrides for requirer and peer, implemented for Provider
+    # Requirer uses local component and switched keys
+    # _local_secret_fields -> PROV_SECRET_FIELDS
+    # _remote_secret_fields -> REQ_SECRET_FIELDS
+    # provider uses remote component and
+    # _local_secret_fields -> REQ_SECRET_FIELDS
+    # _remote_secret_fields -> PROV_SECRET_FIELDS
+    @abstractmethod
+    def _load_secrets_from_databag(self, relation: Relation) -> None:
+        """Load secrets from the databag."""
         raise NotImplementedError
 
-    @abstractmethod
     def _fetch_specific_relation_data(
         self, relation: Relation, fields: Optional[List[str]]
     ) -> Dict[str, str]:
-        """Fetch data available (directily or indirectly -- i.e. secrets) from the relation."""
-        raise NotImplementedError
+        """Fetch data available (directily or indirectly -- i.e. secrets) from the relation (remote app data)."""
+        if not relation.app:
+            return {}
+        self._load_secrets_from_databag(relation)
+        return self._fetch_relation_data_with_secrets(
+            relation.app, self.remote_secret_fields, relation, fields
+        )
 
-    @abstractmethod
     def _fetch_my_specific_relation_data(
         self, relation: Relation, fields: Optional[List[str]]
-    ) -> Dict[str, str]:
-        """Fetch data available (directily or indirectly -- i.e. secrets) from the relation for owner/this_app."""
-        raise NotImplementedError
+    ) -> dict:
+        """Fetch our own relation data."""
+        # load secrets
+        self._load_secrets_from_databag(relation)
+        return self._fetch_relation_data_with_secrets(
+            self.local_app,
+            self.local_secret_fields,
+            relation,
+            fields,
+        )
 
-    @abstractmethod
     def _update_relation_data(self, relation: Relation, data: Dict[str, str]) -> None:
-        """Update data available (directily or indirectly -- i.e. secrets) from the relation for owner/this_app."""
-        raise NotImplementedError
+        """Set values for fields not caring whether it's a secret or not."""
+        self._load_secrets_from_databag(relation)
 
-    @abstractmethod
+        _, normal_fields = self._process_secret_fields(
+            relation,
+            self.local_secret_fields,
+            list(data),
+            self._add_or_update_relation_secrets,
+            data=data,
+        )
+
+        normal_content = {k: v for k, v in data.items() if k in normal_fields}
+        self._update_relation_data_without_secrets(self.local_app, relation, normal_content)
+
+    def _add_or_update_relation_secrets(
+        self,
+        relation: Relation,
+        group: SecretGroup,
+        secret_fields: Set[str],
+        data: Dict[str, str],
+        uri_to_databag=True,
+    ) -> bool:
+        """Update contents for Secret group. If the Secret doesn't exist, create it."""
+        if self._get_relation_secret(relation.id, group):
+            return self._update_relation_secret(relation, group, secret_fields, data)
+
+        return self._add_relation_secret(relation, group, secret_fields, data, uri_to_databag)
+
+    @juju_secrets_only
+    def _add_relation_secret(
+        self,
+        relation: Relation,
+        group_mapping: SecretGroup,
+        secret_fields: Set[str],
+        data: Dict[str, str],
+        uri_to_databag=True,
+    ) -> bool:
+        """Add a new Juju Secret that will be registered in the relation databag."""
+        if uri_to_databag and self.get_secret_uri(relation, group_mapping):
+            logging.error("Secret for relation %s already exists, not adding again", relation.id)
+            return False
+
+        content = self._content_for_secret_group(data, secret_fields, group_mapping)
+
+        label = self._generate_secret_label(self.relation_name, relation.id, group_mapping)
+        secret = self.secrets.add(label, content, relation)
+
+        if uri_to_databag:
+            # According to lint we may not have a Secret ID
+            if not secret.meta or not secret.meta.id:
+                logging.error("Secret is missing Secret ID")
+                raise SecretError("Secret added but is missing Secret ID")
+
+            self.set_secret_uri(relation, group_mapping, secret.meta.id)
+
+        # Return the content that was added
+        return True
+
+    @juju_secrets_only
+    def _update_relation_secret(
+        self,
+        relation: Relation,
+        group_mapping: SecretGroup,
+        secret_fields: Set[str],
+        data: Dict[str, str],
+    ) -> bool:
+        """Update the contents of an existing Juju Secret, referred in the relation databag."""
+        secret = self._get_relation_secret(relation.id, group_mapping)
+
+        if not secret:
+            logging.error("Can't update secret for relation %s", relation.id)
+            return False
+
+        content = self._content_for_secret_group(data, secret_fields, group_mapping)
+
+        old_content = secret.get_content()
+        full_content = copy.deepcopy(old_content)
+        full_content.update(content)
+        secret.set_content(full_content)
+
+        # Return True on success
+        return True
+
+    @juju_secrets_only
+    def _delete_relation_secret(
+        self, relation: Relation, group: SecretGroup, secret_fields: List[str], fields: List[str]
+    ) -> bool:
+        """Update the contents of an existing Juju Secret, referred in the relation databag."""
+        secret = self._get_relation_secret(relation.id, group)
+
+        if not secret:
+            logging.error("Can't delete secret for relation %s", str(relation.id))
+            return False
+
+        old_content = secret.get_content()
+        new_content = copy.deepcopy(old_content)
+        for field in fields:
+            try:
+                new_content.pop(field)
+            except KeyError:
+                logging.debug(
+                    "Non-existing secret was attempted to be removed %s, %s",
+                    str(relation.id),
+                    str(field),
+                )
+                return False
+
+        # Remove secret from the relation if it's fully gone
+        if not new_content:
+            field = self._generate_secret_field_name(group)
+            try:
+                relation.data[self.component].pop(field)
+            except KeyError:
+                pass
+            label = self._generate_secret_label(self.relation_name, relation.id, group)
+            self.secrets.remove(label)
+        else:
+            secret.set_content(new_content)
+
+        # Return the content that was removed
+        return True
+
     def _delete_relation_data(self, relation: Relation, fields: List[str]) -> None:
         """Delete data available (directily or indirectly -- i.e. secrets) from the relation for owner/this_app."""
-        raise NotImplementedError
+        if relation.app:
+            self._load_secrets_from_databag(relation)
+
+        _, normal_fields = self._process_secret_fields(
+            relation, self.local_secret_fields, fields, self._delete_relation_secret, fields=fields
+        )
+        self._delete_relation_data_without_secrets(self.local_app, relation, list(normal_fields))
+
+    def _register_secret_to_relation(
+        self, relation_name: str, relation_id: int, secret_id: str, group: SecretGroup
+    ):
+        """Fetch secrets and apply local label on them.
+
+        [MAGIC HERE]
+        If we fetch a secret using get_secret(id=<ID>, label=<arbitraty_label>),
+        then <arbitraty_label> will be "stuck" on the Secret object, whenever it may
+        appear (i.e. as an event attribute, or fetched manually) on future occasions.
+
+        This will allow us to uniquely identify the secret on Provider side (typically on
+        'secret-changed' events), and map it to the corresponding relation.
+        """
+        label = self._generate_secret_label(relation_name, relation_id, group)
+
+        # Fetching the Secret's meta information ensuring that it's locally getting registered with
+        CachedSecret(self._model, self.component, label, secret_id).meta
+
+    def _register_secrets_to_relation(self, relation: Relation, params_name_list: List[str]):
+        """Make sure that secrets of the provided list are locally 'registered' from the databag.
+
+        More on 'locally registered' magic is described in _register_secret_to_relation() method
+        """
+        if not relation.app:
+            return
+
+        for group in SECRET_GROUPS.groups():
+            secret_field = self._generate_secret_field_name(group)
+            if secret_field in params_name_list and (
+                secret_uri := self.get_secret_uri(relation, group)
+            ):
+                self._register_secret_to_relation(relation.name, relation.id, secret_uri, group)
 
     # Optional overrides
 
@@ -1051,15 +1387,6 @@ class Data(ABC):
         pass
 
     # Internal helper methods
-
-    @staticmethod
-    def _is_relation_active(relation: Relation):
-        """Whether the relation is active based on contained data."""
-        try:
-            _ = repr(relation.data)
-            return True
-        except (RuntimeError, ModelError):
-            return False
 
     @staticmethod
     def _is_secret_field(field: str) -> bool:
@@ -1178,7 +1505,6 @@ class Data(ABC):
             and (self.local_unit == self._model.unit and self.local_unit.is_leader())
             and set(req_secret_fields) & set(relation.data[self.component])
         )
-
         normal_fields = set(impacted_rel_fields)
         if req_secret_fields and self.secrets_enabled and not fallback_to_databag:
             normal_fields = normal_fields - set(req_secret_fields)
@@ -1305,7 +1631,14 @@ class Data(ABC):
     def get_secret_uri(self, relation: Relation, group: SecretGroup) -> Optional[str]:
         """Get the secret URI for the corresponding group."""
         secret_field = self._generate_secret_field_name(group)
-        return relation.data[self.component].get(secret_field)
+        # if the secret is not managed by this component,
+        # we need to fetch it from the other side
+
+        # Fix for the linter
+        if self.my_secret_groups is None:
+            raise DataInterfacesError("Secrets are not enabled for this component")
+        component = self.component if group in self.my_secret_groups else relation.app
+        return relation.data[component].get(secret_field)
 
     def set_secret_uri(self, relation: Relation, group: SecretGroup, secret_uri: str) -> None:
         """Set the secret URI for the corresponding group."""
@@ -1434,6 +1767,32 @@ class EventHandlers(Object):
             self._on_relation_changed_event,
         )
 
+        self.framework.observe(
+            self.charm.on[relation_data.relation_name].relation_created,
+            self._on_relation_created_event,
+        )
+
+        self.framework.observe(
+            charm.on.secret_changed,
+            self._on_secret_changed_event,
+        )
+
+    # Event handlers
+
+    def _on_relation_created_event(self, event: RelationCreatedEvent) -> None:
+        """Event emitted when the relation is created."""
+        pass
+
+    @abstractmethod
+    def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
+        """Event emitted when the relation data has changed."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def _on_secret_changed_event(self, event: SecretChangedEvent) -> None:
+        """Event emitted when the relation data has changed."""
+        raise NotImplementedError
+
     def _diff(self, event: RelationChangedEvent) -> Diff:
         """Retrieves the diff of the data in the relation changed databag.
 
@@ -1445,11 +1804,6 @@ class EventHandlers(Object):
                 keys from the event relation databag.
         """
         return diff(event, self.relation_data.data_component)
-
-    @abstractmethod
-    def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
-        """Event emitted when the relation data has changed."""
-        raise NotImplementedError
 
 
 # Base ProviderData and RequiresData
@@ -1467,165 +1821,11 @@ class ProviderData(Data):
     ) -> None:
         super().__init__(model, relation_name)
         self.data_component = self.local_app
-
-    # Private methods handling secrets
-
-    @juju_secrets_only
-    def _add_relation_secret(
-        self,
-        relation: Relation,
-        group_mapping: SecretGroup,
-        secret_fields: Set[str],
-        data: Dict[str, str],
-        uri_to_databag=True,
-    ) -> bool:
-        """Add a new Juju Secret that will be registered in the relation databag."""
-        if uri_to_databag and self.get_secret_uri(relation, group_mapping):
-            logging.error("Secret for relation %s already exists, not adding again", relation.id)
-            return False
-
-        content = self._content_for_secret_group(data, secret_fields, group_mapping)
-
-        label = self._generate_secret_label(self.relation_name, relation.id, group_mapping)
-        secret = self.secrets.add(label, content, relation)
-
-        # According to lint we may not have a Secret ID
-        if uri_to_databag and secret.meta and secret.meta.id:
-            self.set_secret_uri(relation, group_mapping, secret.meta.id)
-
-        # Return the content that was added
-        return True
-
-    @juju_secrets_only
-    def _update_relation_secret(
-        self,
-        relation: Relation,
-        group_mapping: SecretGroup,
-        secret_fields: Set[str],
-        data: Dict[str, str],
-    ) -> bool:
-        """Update the contents of an existing Juju Secret, referred in the relation databag."""
-        secret = self._get_relation_secret(relation.id, group_mapping)
-
-        if not secret:
-            logging.error("Can't update secret for relation %s", relation.id)
-            return False
-
-        content = self._content_for_secret_group(data, secret_fields, group_mapping)
-
-        old_content = secret.get_content()
-        full_content = copy.deepcopy(old_content)
-        full_content.update(content)
-        secret.set_content(full_content)
-
-        # Return True on success
-        return True
-
-    def _add_or_update_relation_secrets(
-        self,
-        relation: Relation,
-        group: SecretGroup,
-        secret_fields: Set[str],
-        data: Dict[str, str],
-        uri_to_databag=True,
-    ) -> bool:
-        """Update contents for Secret group. If the Secret doesn't exist, create it."""
-        if self._get_relation_secret(relation.id, group):
-            return self._update_relation_secret(relation, group, secret_fields, data)
-        else:
-            return self._add_relation_secret(relation, group, secret_fields, data, uri_to_databag)
-
-    @juju_secrets_only
-    def _delete_relation_secret(
-        self, relation: Relation, group: SecretGroup, secret_fields: List[str], fields: List[str]
-    ) -> bool:
-        """Update the contents of an existing Juju Secret, referred in the relation databag."""
-        secret = self._get_relation_secret(relation.id, group)
-
-        if not secret:
-            logging.error("Can't delete secret for relation %s", str(relation.id))
-            return False
-
-        old_content = secret.get_content()
-        new_content = copy.deepcopy(old_content)
-        for field in fields:
-            try:
-                new_content.pop(field)
-            except KeyError:
-                logging.debug(
-                    "Non-existing secret was attempted to be removed %s, %s",
-                    str(relation.id),
-                    str(field),
-                )
-                return False
-
-        # Remove secret from the relation if it's fully gone
-        if not new_content:
-            field = self._generate_secret_field_name(group)
-            try:
-                relation.data[self.component].pop(field)
-            except KeyError:
-                pass
-            label = self._generate_secret_label(self.relation_name, relation.id, group)
-            self.secrets.remove(label)
-        else:
-            secret.set_content(new_content)
-
-        # Return the content that was removed
-        return True
-
-    # Mandatory internal overrides
-
-    @juju_secrets_only
-    def _get_relation_secret(
-        self, relation_id: int, group_mapping: SecretGroup, relation_name: Optional[str] = None
-    ) -> Optional[CachedSecret]:
-        """Retrieve a Juju Secret that's been stored in the relation databag."""
-        if not relation_name:
-            relation_name = self.relation_name
-
-        label = self._generate_secret_label(relation_name, relation_id, group_mapping)
-        if secret := self.secrets.get(label):
-            return secret
-
-        relation = self._model.get_relation(relation_name, relation_id)
-        if not relation:
-            return
-
-        if secret_uri := self.get_secret_uri(relation, group_mapping):
-            return self.secrets.get(label, secret_uri)
-
-    def _fetch_specific_relation_data(
-        self, relation: Relation, fields: Optional[List[str]]
-    ) -> Dict[str, str]:
-        """Fetching relation data for Provider.
-
-        NOTE: Since all secret fields are in the Provider side of the databag, we don't need to worry about that
-        """
-        if not relation.app:
-            return {}
-
-        return self._fetch_relation_data_without_secrets(relation.app, relation, fields)
-
-    def _fetch_my_specific_relation_data(
-        self, relation: Relation, fields: Optional[List[str]]
-    ) -> dict:
-        """Fetching our own relation data."""
-        secret_fields = None
-        if relation.app:
-            secret_fields = get_encoded_list(relation, relation.app, REQ_SECRET_FIELDS)
-
-        return self._fetch_relation_data_with_secrets(
-            self.local_app,
-            secret_fields,
-            relation,
-            fields,
-        )
+        self._local_secret_fields = []
+        self._remote_secret_fields = list(self.SECRET_FIELDS)
 
     def _update_relation_data(self, relation: Relation, data: Dict[str, str]) -> None:
         """Set values for fields not caring whether it's a secret or not."""
-        req_secret_fields = []
-
         keys = set(data.keys())
         if self.fetch_relation_field(relation.id, self.RESOURCE_FIELD) is None and (
             keys - {"endpoints", "read-only-endpoints", "replset"}
@@ -1633,31 +1833,7 @@ class ProviderData(Data):
             raise PrematureDataAccessError(
                 "Premature access to relation data, update is forbidden before the connection is initialized."
             )
-
-        if relation.app:
-            req_secret_fields = get_encoded_list(relation, relation.app, REQ_SECRET_FIELDS)
-
-        _, normal_fields = self._process_secret_fields(
-            relation,
-            req_secret_fields,
-            list(data),
-            self._add_or_update_relation_secrets,
-            data=data,
-        )
-
-        normal_content = {k: v for k, v in data.items() if k in normal_fields}
-        self._update_relation_data_without_secrets(self.local_app, relation, normal_content)
-
-    def _delete_relation_data(self, relation: Relation, fields: List[str]) -> None:
-        """Delete fields from the Relation not caring whether it's a secret or not."""
-        req_secret_fields = []
-        if relation.app:
-            req_secret_fields = get_encoded_list(relation, relation.app, REQ_SECRET_FIELDS)
-
-        _, normal_fields = self._process_secret_fields(
-            relation, req_secret_fields, fields, self._delete_relation_secret, fields=fields
-        )
-        self._delete_relation_data_without_secrets(self.local_app, relation, list(normal_fields))
+        super()._update_relation_data(relation, data)
 
     # Public methods - "native"
 
@@ -1673,6 +1849,24 @@ class ProviderData(Data):
             password: password of the created user.
         """
         self.update_relation_data(relation_id, {"username": username, "password": password})
+
+    def set_entity_credentials(
+        self, relation_id: int, entity_name: str, entity_password: Optional[str] = None
+    ) -> None:
+        """Set entity credentials.
+
+        This function writes in the application data bag, therefore,
+        only the leader unit can call it.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            entity_name: name of the created entity
+            entity_password: password of the created entity.
+        """
+        self.update_relation_data(
+            relation_id,
+            {"entity-name": entity_name, "entity-password": entity_password},
+        )
 
     def set_tls(self, relation_id: int, tls: str) -> None:
         """Set whether TLS is enabled.
@@ -1697,11 +1891,30 @@ class ProviderData(Data):
     fetch_my_relation_data = leader_only(Data.fetch_my_relation_data)
     fetch_my_relation_field = leader_only(Data.fetch_my_relation_field)
 
+    def _load_secrets_from_databag(self, relation: Relation) -> None:
+        """Load secrets from the databag."""
+        requested_secrets = get_encoded_list(relation, relation.app, REQ_SECRET_FIELDS)
+        provided_secrets = get_encoded_list(relation, relation.app, PROV_SECRET_FIELDS)
+        if requested_secrets is not None:
+            self._local_secret_fields = requested_secrets
+
+        if provided_secrets is not None:
+            self._remote_secret_fields = provided_secrets
+
 
 class RequirerData(Data):
     """Requirer-side of the relation."""
 
-    SECRET_FIELDS = ["username", "password", "tls", "tls-ca", "uris", "read-only-uris"]
+    SECRET_FIELDS = [
+        "username",
+        "password",
+        "tls",
+        "tls-ca",
+        "uris",
+        "read-only-uris",
+        "entity-name",
+        "entity-password",
+    ]
 
     def __init__(
         self,
@@ -1709,75 +1922,75 @@ class RequirerData(Data):
         relation_name: str,
         extra_user_roles: Optional[str] = None,
         additional_secret_fields: Optional[List[str]] = [],
+        extra_group_roles: Optional[str] = None,
+        entity_type: Optional[str] = None,
+        entity_permissions: Optional[str] = None,
     ):
         """Manager of base client relations."""
         super().__init__(model, relation_name)
         self.extra_user_roles = extra_user_roles
-        self._secret_fields = list(self.SECRET_FIELDS)
+        self.extra_group_roles = extra_group_roles
+        self.entity_type = entity_type
+        self.entity_permissions = entity_permissions
+
+        self._validate_entity_type()
+        self._validate_entity_permissions()
+
+        self._remote_secret_fields = list(self.SECRET_FIELDS)
+        self._local_secret_fields = [
+            field
+            for field in self.SECRET_LABEL_MAP.keys()
+            if field not in self._remote_secret_fields
+        ]
         if additional_secret_fields:
-            self._secret_fields += additional_secret_fields
+            self._remote_secret_fields += additional_secret_fields
         self.data_component = self.local_unit
 
-    @property
-    def secret_fields(self) -> Optional[List[str]]:
-        """Local access to secrets field, in case they are being used."""
-        if self.secrets_enabled:
-            return self._secret_fields
-
-    # Internal helper functions
-
-    def _register_secret_to_relation(
-        self, relation_name: str, relation_id: int, secret_id: str, group: SecretGroup
-    ):
-        """Fetch secrets and apply local label on them.
-
-        [MAGIC HERE]
-        If we fetch a secret using get_secret(id=<ID>, label=<arbitraty_label>),
-        then <arbitraty_label> will be "stuck" on the Secret object, whenever it may
-        appear (i.e. as an event attribute, or fetched manually) on future occasions.
-
-        This will allow us to uniquely identify the secret on Provider side (typically on
-        'secret-changed' events), and map it to the corresponding relation.
-        """
-        label = self._generate_secret_label(relation_name, relation_id, group)
-
-        # Fetching the Secret's meta information ensuring that it's locally getting registered with
-        CachedSecret(self._model, self.component, label, secret_id).meta
-
-    def _register_secrets_to_relation(self, relation: Relation, params_name_list: List[str]):
-        """Make sure that secrets of the provided list are locally 'registered' from the databag.
-
-        More on 'locally registered' magic is described in _register_secret_to_relation() method
-        """
-        if not relation.app:
-            return
-
-        for group in SECRET_GROUPS.groups():
-            secret_field = self._generate_secret_field_name(group)
-            if secret_field in params_name_list and (
-                secret_uri := self.get_secret_uri(relation, group)
-            ):
-                self._register_secret_to_relation(relation.name, relation.id, secret_uri, group)
+    # Internal functions
 
     def _is_resource_created_for_relation(self, relation: Relation) -> bool:
         if not relation.app:
             return False
 
-        data = self.fetch_relation_data([relation.id], ["username", "password"]).get(
-            relation.id, {}
+        data = self.fetch_relation_data(
+            [relation.id],
+            ["username", "password", "entity-name", "entity-password"],
+        ).get(relation.id, {})
+
+        return any(
+            [
+                all(bool(data.get(field)) for field in ("username", "password")),
+                all(bool(data.get(field)) for field in ("entity-name",)),
+            ]
         )
-        return bool(data.get("username")) and bool(data.get("password"))
+
+    def _validate_entity_type(self) -> None:
+        """Validates the consistency of the provided entity-type and its extra roles."""
+        if self.entity_type and self.entity_type not in {ENTITY_USER, ENTITY_GROUP}:
+            raise ValueError("Invalid entity-type. Possible values are USER and GROUP")
+
+        if self.entity_type == ENTITY_USER and self.extra_group_roles:
+            raise ValueError("Inconsistent entity information. Use extra_user_roles instead")
+
+        if self.entity_type == ENTITY_GROUP and self.extra_user_roles:
+            raise ValueError("Inconsistent entity information. Use extra_group_roles instead")
+
+    def _validate_entity_permissions(self) -> None:
+        """Validates whether the provided entity permissions follow the right JSON format."""
+        if not self.entity_permissions:
+            return
+
+        accepted_keys = {"resource_name", "resource_type", "privileges"}
+
+        try:
+            permissions = json.loads(self.entity_permissions)
+            for permission in permissions:
+                if permission.keys() != accepted_keys:
+                    raise ValueError("Invalid entity permissions format. See accepted keys")
+        except json.decoder.JSONDecodeError:
+            raise ValueError("Invalid entity permissions format. It must be JSON format")
 
     # Public functions
-
-    def get_secret_uri(self, relation: Relation, group: SecretGroup) -> Optional[str]:
-        """Getting relation secret URI for the corresponding Secret Group."""
-        secret_field = self._generate_secret_field_name(group)
-        return relation.data[relation.app].get(secret_field)
-
-    def set_secret_uri(self, relation: Relation, group: SecretGroup, uri: str) -> None:
-        """Setting relation secret URI is not possible for a Requirer."""
-        raise NotImplementedError("Requirer can not change the relation secret URI.")
 
     def is_resource_created(self, relation_id: Optional[int] = None) -> bool:
         """Check if the resource has been created.
@@ -1812,62 +2025,20 @@ class RequirerData(Data):
                 else False
             )
 
-    # Mandatory internal overrides
-
-    @juju_secrets_only
-    def _get_relation_secret(
-        self, relation_id: int, group: SecretGroup, relation_name: Optional[str] = None
-    ) -> Optional[CachedSecret]:
-        """Retrieve a Juju Secret that's been stored in the relation databag."""
-        if not relation_name:
-            relation_name = self.relation_name
-
-        label = self._generate_secret_label(relation_name, relation_id, group)
-        return self.secrets.get(label)
-
-    def _fetch_specific_relation_data(
-        self, relation, fields: Optional[List[str]] = None
-    ) -> Dict[str, str]:
-        """Fetching Requirer data -- that may include secrets."""
-        if not relation.app:
-            return {}
-        return self._fetch_relation_data_with_secrets(
-            relation.app, self.secret_fields, relation, fields
-        )
-
-    def _fetch_my_specific_relation_data(self, relation, fields: Optional[List[str]]) -> dict:
-        """Fetching our own relation data."""
-        return self._fetch_relation_data_without_secrets(self.local_app, relation, fields)
-
-    def _update_relation_data(self, relation: Relation, data: dict) -> None:
-        """Updates a set of key-value pairs in the relation.
-
-        This function writes in the application data bag, therefore,
-        only the leader unit can call it.
-
-        Args:
-            relation: the particular relation.
-            data: dict containing the key-value pairs
-                that should be updated in the relation.
-        """
-        return self._update_relation_data_without_secrets(self.local_app, relation, data)
-
-    def _delete_relation_data(self, relation: Relation, fields: List[str]) -> None:
-        """Deletes a set of fields from the relation.
-
-        This function writes in the application data bag, therefore,
-        only the leader unit can call it.
-
-        Args:
-            relation: the particular relation.
-            fields: list containing the field names that should be removed from the relation.
-        """
-        return self._delete_relation_data_without_secrets(self.local_app, relation, fields)
-
     # Public functions -- inherited
 
     fetch_my_relation_data = leader_only(Data.fetch_my_relation_data)
     fetch_my_relation_field = leader_only(Data.fetch_my_relation_field)
+
+    def _load_secrets_from_databag(self, relation: Relation) -> None:
+        """Load secrets from the databag."""
+        requested_secrets = get_encoded_list(relation, self.local_unit, REQ_SECRET_FIELDS)
+        provided_secrets = get_encoded_list(relation, self.local_unit, PROV_SECRET_FIELDS)
+        if requested_secrets:
+            self._remote_secret_fields = requested_secrets
+
+        if provided_secrets:
+            self._local_secret_fields = provided_secrets
 
 
 class RequirerEventHandlers(EventHandlers):
@@ -1877,13 +2048,24 @@ class RequirerEventHandlers(EventHandlers):
         """Manager of base client relations."""
         super().__init__(charm, relation_data, unique_key)
 
-        self.framework.observe(
-            self.charm.on[relation_data.relation_name].relation_created,
-            self._on_relation_created_event,
+    def _main_credentials_shared(self, diff: Diff) -> bool:
+        """Whether the relation data-bag contains username / password keys."""
+        user_secret = self.relation_data._generate_secret_field_name(SECRET_GROUPS.USER)
+        return any(
+            [
+                user_secret in diff.added,
+                "username" in diff.added and "password" in diff.added,
+            ]
         )
-        self.framework.observe(
-            charm.on.secret_changed,
-            self._on_secret_changed_event,
+
+    def _entity_credentials_shared(self, diff: Diff) -> bool:
+        """Whether the relation data-bag contains rolename / password keys."""
+        entity_secret = self.relation_data._generate_secret_field_name(SECRET_GROUPS.ENTITY)
+        return any(
+            [
+                entity_secret in diff.added,
+                "entity-name" in diff.added,
+            ]
         )
 
     # Event handlers
@@ -1893,18 +2075,71 @@ class RequirerEventHandlers(EventHandlers):
         if not self.relation_data.local_unit.is_leader():
             return
 
-        if self.relation_data.secret_fields:  # pyright: ignore [reportAttributeAccessIssue]
+        if self.relation_data.remote_secret_fields:
+            if self.relation_data.SCOPE == Scope.APP:
+                set_encoded_field(
+                    event.relation,
+                    self.relation_data.local_app,
+                    REQ_SECRET_FIELDS,
+                    self.relation_data.remote_secret_fields,
+                )
+
             set_encoded_field(
                 event.relation,
-                self.relation_data.component,
+                self.relation_data.local_unit,
                 REQ_SECRET_FIELDS,
-                self.relation_data.secret_fields,  # pyright: ignore [reportAttributeAccessIssue]
+                self.relation_data.remote_secret_fields,
             )
 
-    @abstractmethod
-    def _on_secret_changed_event(self, event: RelationChangedEvent) -> None:
+        if self.relation_data.local_secret_fields:
+            if self.relation_data.SCOPE == Scope.APP:
+                set_encoded_field(
+                    event.relation,
+                    self.relation_data.local_app,
+                    PROV_SECRET_FIELDS,
+                    self.relation_data.local_secret_fields,
+                )
+            set_encoded_field(
+                event.relation,
+                self.relation_data.local_unit,
+                PROV_SECRET_FIELDS,
+                self.relation_data.local_secret_fields,
+            )
+
+
+class ProviderEventHandlers(EventHandlers):
+    """Provider-side of the relation."""
+
+    def __init__(self, charm: CharmBase, relation_data: ProviderData, unique_key: str = ""):
+        """Manager of base client relations."""
+        super().__init__(charm, relation_data, unique_key)
+
+    @staticmethod
+    def _validate_entity_consistency(event: RelationEvent, diff: Diff) -> None:
+        """Validates that entity information is not changed after relation is established.
+
+        - When entity-type changes, backwards compatibility is broken.
+        - When extra-user-roles changes, role membership checks become incredibly complex.
+        - When extra-group-roles changes, role membership checks become incredibly complex.
+        """
+        if not isinstance(event, RelationChangedEvent):
+            return
+
+        for key in ["entity-type", "extra-user-roles", "extra-group-roles"]:
+            if key in diff.changed:
+                raise ValueError(f"Cannot change {key} after relation has already been created")
+
+    # Event handlers
+
+    def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
         """Event emitted when the relation data has changed."""
-        raise NotImplementedError
+        requested_secrets = get_encoded_list(event.relation, event.relation.app, REQ_SECRET_FIELDS)
+        provided_secrets = get_encoded_list(event.relation, event.relation.app, PROV_SECRET_FIELDS)
+        if requested_secrets is not None:
+            self.relation_data._local_secret_fields = requested_secrets
+
+        if provided_secrets is not None:
+            self.relation_data._remote_secret_fields = provided_secrets
 
 
 ################################################################################
@@ -1923,7 +2158,6 @@ class DataPeerData(RequirerData, ProviderData):
         self,
         model,
         relation_name: str,
-        extra_user_roles: Optional[str] = None,
         additional_secret_fields: Optional[List[str]] = [],
         additional_secret_group_mapping: Dict[str, str] = {},
         secret_field_name: Optional[str] = None,
@@ -1931,10 +2165,9 @@ class DataPeerData(RequirerData, ProviderData):
     ):
         RequirerData.__init__(
             self,
-            model,
-            relation_name,
-            extra_user_roles,
-            additional_secret_fields,
+            model=model,
+            relation_name=relation_name,
+            additional_secret_fields=additional_secret_fields,
         )
         self.secret_field_name = secret_field_name if secret_field_name else self.SECRET_FIELD_NAME
         self.deleted_label = deleted_label
@@ -1955,7 +2188,7 @@ class DataPeerData(RequirerData, ProviderData):
                 secret_group = SECRET_GROUPS.get_group(group)
                 internal_field = self._field_to_internal_name(field, secret_group)
                 self._secret_label_map.setdefault(group, []).append(internal_field)
-                self._secret_fields.append(internal_field)
+                self._remote_secret_fields.append(internal_field)
 
     @property
     def scope(self) -> Optional[Scope]:
@@ -1973,10 +2206,10 @@ class DataPeerData(RequirerData, ProviderData):
     @property
     def static_secret_fields(self) -> List[str]:
         """Re-definition of the property in a way that dynamically extended list is retrieved."""
-        return self._secret_fields
+        return self._remote_secret_fields
 
     @property
-    def secret_fields(self) -> List[str]:
+    def local_secret_fields(self) -> List[str]:
         """Re-definition of the property in a way that dynamically extended list is retrieved."""
         return (
             self.static_secret_fields if self.static_secret_fields else self.current_secret_fields
@@ -1994,7 +2227,12 @@ class DataPeerData(RequirerData, ProviderData):
         relation = self._model.relations[self.relation_name][0]
         fields = []
 
-        ignores = [SECRET_GROUPS.get_group("user"), SECRET_GROUPS.get_group("tls")]
+        ignores = [
+            SECRET_GROUPS.get_group("user"),
+            SECRET_GROUPS.get_group("tls"),
+            SECRET_GROUPS.get_group("mtls"),
+            SECRET_GROUPS.get_group("entity"),
+        ]
         for group in SECRET_GROUPS.groups():
             if group in ignores:
                 continue
@@ -2103,11 +2341,11 @@ class DataPeerData(RequirerData, ProviderData):
     ) -> Dict[str, str]:
         """Select <field>: <value> pairs from input, that belong to this particular Secret group."""
         if group_mapping == SECRET_GROUPS.EXTRA:
-            return {k: v for k, v in content.items() if k in self.secret_fields}
+            return {k: v for k, v in content.items() if k in self.local_secret_fields}
         return {
             self._internal_name_to_field(k)[0]: v
             for k, v in content.items()
-            if k in self.secret_fields
+            if k in self.local_secret_fields
         }
 
     def valid_field_pattern(self, field: str, full_field: str) -> bool:
@@ -2121,6 +2359,16 @@ class DataPeerData(RequirerData, ProviderData):
             )
             return False
         return True
+
+    def _load_secrets_from_databag(self, relation: Relation) -> None:
+        """Load secrets from the databag."""
+        requested_secrets = get_encoded_list(relation, self.component, REQ_SECRET_FIELDS)
+        provided_secrets = get_encoded_list(relation, self.component, PROV_SECRET_FIELDS)
+        if requested_secrets:
+            self._remote_secret_fields = requested_secrets
+
+        if provided_secrets:
+            self._local_secret_fields = provided_secrets
 
     ##########################################################################
     # Backwards compatibility / Upgrades
@@ -2177,7 +2425,7 @@ class DataPeerData(RequirerData, ProviderData):
         if current_data is not None:
             # Check if the secret we wanna delete actually exists
             # Given the "deleted label", here we can't rely on the default mechanism (i.e. 'key not found')
-            if non_existent := (set(fields) & set(self.secret_fields)) - set(
+            if non_existent := (set(fields) & set(self.local_secret_fields)) - set(
                 current_data.get(relation.id, [])
             ):
                 logger.debug(
@@ -2227,10 +2475,10 @@ class DataPeerData(RequirerData, ProviderData):
         Practically what happens here is to remove stuff from the databag that is
         to be stored in secrets.
         """
-        if not self.secret_fields:
+        if not self.local_secret_fields:
             return
 
-        secret_fields_passed = set(self.secret_fields) & set(fields)
+        secret_fields_passed = set(self.local_secret_fields) & set(fields)
         for field in secret_fields_passed:
             if self._fetch_relation_data_without_secrets(self.component, relation, [field]):
                 self._delete_relation_data_without_secrets(self.component, relation, [field])
@@ -2342,15 +2590,17 @@ class DataPeerData(RequirerData, ProviderData):
     ) -> Dict[str, str]:
         """Fetch data available (directily or indirectly -- i.e. secrets) from the relation for owner/this_app."""
         return self._fetch_relation_data_with_secrets(
-            self.component, self.secret_fields, relation, fields
+            self.component, self.local_secret_fields, relation, fields
         )
 
     @either_static_or_dynamic_secrets
     def _update_relation_data(self, relation: Relation, data: Dict[str, str]) -> None:
         """Update data available (directily or indirectly -- i.e. secrets) from the relation for owner/this_app."""
+        self._load_secrets_from_databag(relation)
+
         _, normal_fields = self._process_secret_fields(
             relation,
-            self.secret_fields,
+            self.local_secret_fields,
             list(data),
             self._add_or_update_relation_secrets,
             data=data,
@@ -2363,17 +2613,22 @@ class DataPeerData(RequirerData, ProviderData):
     @either_static_or_dynamic_secrets
     def _delete_relation_data(self, relation: Relation, fields: List[str]) -> None:
         """Delete data available (directily or indirectly -- i.e. secrets) from the relation for owner/this_app."""
-        if self.secret_fields and self.deleted_label:
+        self._load_secrets_from_databag(relation)
+        if self.local_secret_fields and self.deleted_label:
             _, normal_fields = self._process_secret_fields(
                 relation,
-                self.secret_fields,
+                self.local_secret_fields,
                 fields,
                 self._update_relation_secret,
                 data=dict.fromkeys(fields, self.deleted_label),
             )
         else:
             _, normal_fields = self._process_secret_fields(
-                relation, self.secret_fields, fields, self._delete_relation_secret, fields=fields
+                relation,
+                self.local_secret_fields,
+                fields,
+                self._delete_relation_secret,
+                fields=fields,
             )
         self._delete_relation_data_without_secrets(self.component, relation, list(normal_fields))
 
@@ -2429,7 +2684,6 @@ class DataPeer(DataPeerData, DataPeerEventHandlers):
         self,
         charm,
         relation_name: str,
-        extra_user_roles: Optional[str] = None,
         additional_secret_fields: Optional[List[str]] = [],
         additional_secret_group_mapping: Dict[str, str] = {},
         secret_field_name: Optional[str] = None,
@@ -2440,7 +2694,6 @@ class DataPeer(DataPeerData, DataPeerEventHandlers):
             self,
             charm.model,
             relation_name,
-            extra_user_roles,
             additional_secret_fields,
             additional_secret_group_mapping,
             secret_field_name,
@@ -2465,7 +2718,6 @@ class DataPeerUnit(DataPeerUnitData, DataPeerEventHandlers):
         self,
         charm,
         relation_name: str,
-        extra_user_roles: Optional[str] = None,
         additional_secret_fields: Optional[List[str]] = [],
         additional_secret_group_mapping: Dict[str, str] = {},
         secret_field_name: Optional[str] = None,
@@ -2476,7 +2728,6 @@ class DataPeerUnit(DataPeerUnitData, DataPeerEventHandlers):
             self,
             charm.model,
             relation_name,
-            extra_user_roles,
             additional_secret_fields,
             additional_secret_group_mapping,
             secret_field_name,
@@ -2519,7 +2770,6 @@ class DataPeerOtherUnit(DataPeerOtherUnitData, DataPeerOtherUnitEventHandlers):
         unit: Unit,
         charm: CharmBase,
         relation_name: str,
-        extra_user_roles: Optional[str] = None,
         additional_secret_fields: Optional[List[str]] = [],
         additional_secret_group_mapping: Dict[str, str] = {},
         secret_field_name: Optional[str] = None,
@@ -2530,7 +2780,6 @@ class DataPeerOtherUnit(DataPeerOtherUnitData, DataPeerOtherUnitEventHandlers):
             unit,
             charm.model,
             relation_name,
-            extra_user_roles,
             additional_secret_fields,
             additional_secret_group_mapping,
             secret_field_name,
@@ -2540,22 +2789,10 @@ class DataPeerOtherUnit(DataPeerOtherUnitData, DataPeerOtherUnitEventHandlers):
 
 
 ################################################################################
-# Cross-charm Relatoins Data Handling and Evenets
+# Cross-charm Relations Data Handling and Events
 ################################################################################
 
 # Generic events
-
-
-class ExtraRoleEvent(RelationEvent):
-    """Base class for data events."""
-
-    @property
-    def extra_user_roles(self) -> Optional[str]:
-        """Returns the extra user roles that were requested."""
-        if not self.relation.app:
-            return None
-
-        return self.relation.data[self.relation.app].get("extra-user-roles")
 
 
 class RelationEventWithSecret(RelationEvent):
@@ -2587,6 +2824,76 @@ class RelationEventWithSecret(RelationEvent):
     def secrets_enabled(self):
         """Is this Juju version allowing for Secrets usage?"""
         return JujuVersion.from_environ().has_secrets
+
+
+class EntityProvidesEvent(RelationEvent):
+    """Base class for data events."""
+
+    @property
+    def extra_user_roles(self) -> Optional[str]:
+        """Returns the extra user roles that were requested."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("extra-user-roles")
+
+    @property
+    def extra_group_roles(self) -> Optional[str]:
+        """Returns the extra group roles that were requested."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("extra-group-roles")
+
+    @property
+    def entity_type(self) -> Optional[str]:
+        """Returns the entity_type that were requested."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("entity-type")
+
+    @property
+    def entity_permissions(self) -> Optional[str]:
+        """Returns the entity_permissions that were requested."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("entity-permissions")
+
+
+class EntityRequiresEvent(RelationEventWithSecret):
+    """Base class for authentication fields for events.
+
+    The amount of logic added here is not ideal -- but this was the only way to preserve
+    the interface when moving to Juju Secrets
+    """
+
+    @property
+    def entity_name(self) -> Optional[str]:
+        """Returns the name for the created entity."""
+        if not self.relation.app:
+            return None
+
+        if self.secrets_enabled:
+            secret = self._get_secret("entity")
+            if secret:
+                return secret.get("entity-name")
+
+        return self.relation.data[self.relation.app].get("entity-name")
+
+    @property
+    def entity_password(self) -> Optional[str]:
+        """Returns the password for the created entity."""
+        if not self.relation.app:
+            return None
+
+        if self.secrets_enabled:
+            secret = self._get_secret("entity")
+            if secret:
+                return secret.get("entity-password")
+
+        return self.relation.data[self.relation.app].get("entity-password")
 
 
 class AuthenticationEvent(RelationEventWithSecret):
@@ -2664,8 +2971,16 @@ class DatabaseProvidesEvent(RelationEvent):
         return self.relation.data[self.relation.app].get("database")
 
 
-class DatabaseRequestedEvent(DatabaseProvidesEvent, ExtraRoleEvent):
+class DatabaseRequestedEvent(DatabaseProvidesEvent):
     """Event emitted when a new database is requested for use on this relation."""
+
+    @property
+    def extra_user_roles(self) -> Optional[str]:
+        """Returns the extra user roles that were requested."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("extra-user-roles")
 
     @property
     def external_node_connectivity(self) -> bool:
@@ -2679,6 +2994,14 @@ class DatabaseRequestedEvent(DatabaseProvidesEvent, ExtraRoleEvent):
         )
 
 
+class DatabaseEntityRequestedEvent(DatabaseProvidesEvent, EntityProvidesEvent):
+    """Event emitted when a new entity is requested for use on this relation."""
+
+
+class DatabaseEntityPermissionsChangedEvent(DatabaseProvidesEvent, EntityProvidesEvent):
+    """Event emitted when existing entity permissions are changed on this relation."""
+
+
 class DatabaseProvidesEvents(CharmEvents):
     """Database events.
 
@@ -2686,6 +3009,8 @@ class DatabaseProvidesEvents(CharmEvents):
     """
 
     database_requested = EventSource(DatabaseRequestedEvent)
+    database_entity_requested = EventSource(DatabaseEntityRequestedEvent)
+    database_entity_permissions_changed = EventSource(DatabaseEntityPermissionsChangedEvent)
 
 
 class DatabaseRequiresEvent(RelationEventWithSecret):
@@ -2779,6 +3104,10 @@ class DatabaseCreatedEvent(AuthenticationEvent, DatabaseRequiresEvent):
     """Event emitted when a new database is created for use on this relation."""
 
 
+class DatabaseEntityCreatedEvent(EntityRequiresEvent, DatabaseRequiresEvent):
+    """Event emitted when a new entity is created for use on this relation."""
+
+
 class DatabaseEndpointsChangedEvent(AuthenticationEvent, DatabaseRequiresEvent):
     """Event emitted when the read/write endpoints are changed."""
 
@@ -2794,6 +3123,7 @@ class DatabaseRequiresEvents(CharmEvents):
     """
 
     database_created = EventSource(DatabaseCreatedEvent)
+    database_entity_created = EventSource(DatabaseEntityCreatedEvent)
     endpoints_changed = EventSource(DatabaseEndpointsChangedEvent)
     read_only_endpoints_changed = EventSource(DatabaseReadOnlyEndpointsChangedEvent)
 
@@ -2896,7 +3226,7 @@ class DatabaseProviderData(ProviderData):
         self.update_relation_data(relation_id, {"subordinated": "true"})
 
 
-class DatabaseProviderEventHandlers(EventHandlers):
+class DatabaseProviderEventHandlers(ProviderEventHandlers):
     """Provider-side of the database relation handlers."""
 
     on = DatabaseProvidesEvents()  # pyright: ignore [reportAssignmentType]
@@ -2911,18 +3241,54 @@ class DatabaseProviderEventHandlers(EventHandlers):
 
     def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
         """Event emitted when the relation has changed."""
+        super()._on_relation_changed_event(event)
         # Leader only
         if not self.relation_data.local_unit.is_leader():
             return
+
         # Check which data has changed to emit customs events.
         diff = self._diff(event)
 
-        # Emit a database requested event if the setup key (database name and optional
-        # extra user roles) was added to the relation databag by the application.
-        if "database" in diff.added:
+        # Validate entity information is not dynamically changed
+        self._validate_entity_consistency(event, diff)
+
+        # Emit a database requested event if the setup key (database name)
+        # was added to the relation databag, but the entity-type key was not.
+        if "database" in diff.added and "entity-type" not in diff.added:
             getattr(self.on, "database_requested").emit(
                 event.relation, app=event.app, unit=event.unit
             )
+
+            # To avoid unnecessary application restarts do not trigger other events.
+            return
+
+        # Emit an entity requested event if the setup key (database name)
+        # was added to the relation databag, in addition to the entity-type key.
+        if "database" in diff.added and "entity-type" in diff.added:
+            getattr(self.on, "database_entity_requested").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+
+            # To avoid unnecessary application restarts do not trigger other events.
+            return
+
+        # Emit a permissions changed event if the setup key (database name)
+        # was added to the relation databag, and the entity-permissions key changed.
+        if (
+            "database" not in diff.added
+            and "entity-type" not in diff.added
+            and ("entity-permissions" in diff.added or "entity-permissions" in diff.changed)
+        ):
+            getattr(self.on, "database_entity_permissions_changed").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+
+            # To avoid unnecessary application restarts do not trigger other events.
+            return
+
+    def _on_secret_changed_event(self, event: SecretChangedEvent) -> None:
+        """Event emitted when the secret has changed."""
+        pass
 
 
 class DatabaseProvides(DatabaseProviderData, DatabaseProviderEventHandlers):
@@ -2945,9 +3311,20 @@ class DatabaseRequirerData(RequirerData):
         relations_aliases: Optional[List[str]] = None,
         additional_secret_fields: Optional[List[str]] = [],
         external_node_connectivity: bool = False,
+        extra_group_roles: Optional[str] = None,
+        entity_type: Optional[str] = None,
+        entity_permissions: Optional[str] = None,
     ):
         """Manager of database client relations."""
-        super().__init__(model, relation_name, extra_user_roles, additional_secret_fields)
+        super().__init__(
+            model,
+            relation_name,
+            extra_user_roles,
+            additional_secret_fields,
+            extra_group_roles,
+            entity_type,
+            entity_permissions,
+        )
         self.database = database_name
         self.relations_aliases = relations_aliases
         self.external_node_connectivity = external_node_connectivity
@@ -3030,9 +3407,17 @@ class DatabaseRequirerEventHandlers(RequirerEventHandlers):
 
         if self.relation_data.relations_aliases:
             for relation_alias in self.relation_data.relations_aliases:
-                self.on.define_event(f"{relation_alias}_database_created", DatabaseCreatedEvent)
                 self.on.define_event(
-                    f"{relation_alias}_endpoints_changed", DatabaseEndpointsChangedEvent
+                    f"{relation_alias}_database_created",
+                    DatabaseCreatedEvent,
+                )
+                self.on.define_event(
+                    f"{relation_alias}_database_entity_created",
+                    DatabaseEntityCreatedEvent,
+                )
+                self.on.define_event(
+                    f"{relation_alias}_endpoints_changed",
+                    DatabaseEndpointsChangedEvent,
                 )
                 self.on.define_event(
                     f"{relation_alias}_read_only_endpoints_changed",
@@ -3122,6 +3507,12 @@ class DatabaseRequirerEventHandlers(RequirerEventHandlers):
 
         if self.relation_data.extra_user_roles:
             event_data["extra-user-roles"] = self.relation_data.extra_user_roles
+        if self.relation_data.extra_group_roles:
+            event_data["extra-group-roles"] = self.relation_data.extra_group_roles
+        if self.relation_data.entity_type:
+            event_data["entity-type"] = self.relation_data.entity_type
+        if self.relation_data.entity_permissions:
+            event_data["entity-permissions"] = self.relation_data.entity_permissions
 
         # set external-node-connectivity field
         if self.relation_data.external_node_connectivity:
@@ -3140,10 +3531,7 @@ class DatabaseRequirerEventHandlers(RequirerEventHandlers):
                 is_subordinate = event.relation.data[key].get("subordinated") == "true"
 
         if is_subordinate:
-            if not remote_unit_data:
-                return
-
-            if remote_unit_data.get("state") != "ready":
+            if not remote_unit_data or remote_unit_data.get("state") != "ready":
                 return
 
         # Check which data has changed to emit customs events.
@@ -3153,12 +3541,13 @@ class DatabaseRequirerEventHandlers(RequirerEventHandlers):
         if any(newval for newval in diff.added if self.relation_data._is_secret_field(newval)):
             self.relation_data._register_secrets_to_relation(event.relation, diff.added)
 
+        app_databag = get_encoded_dict(event.relation, event.app, "data")
+        if app_databag is None:
+            app_databag = {}
+
         # Check if the database is created
         # (the database charm shared the credentials).
-        secret_field_user = self.relation_data._generate_secret_field_name(SECRET_GROUPS.USER)
-        if (
-            "username" in diff.added and "password" in diff.added
-        ) or secret_field_user in diff.added:
+        if self._main_credentials_shared(diff) and "entity-type" not in app_databag:
             # Emit the default event (the one without an alias).
             logger.info("database created at %s", datetime.now())
             getattr(self.on, "database_created").emit(
@@ -3168,8 +3557,20 @@ class DatabaseRequirerEventHandlers(RequirerEventHandlers):
             # Emit the aliased event (if any).
             self._emit_aliased_event(event, "database_created")
 
-            # To avoid unnecessary application restarts do not trigger
-            # “endpoints_changed“ event if “database_created“ is triggered.
+            # To avoid unnecessary application restarts do not trigger other events.
+            return
+
+        if self._entity_credentials_shared(diff) and "entity-type" in app_databag:
+            # Emit the default event (the one without an alias).
+            logger.info("entity created at %s", datetime.now())
+            getattr(self.on, "database_entity_created").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+
+            # Emit the aliased event (if any).
+            self._emit_aliased_event(event, "database_entity_created")
+
+            # To avoid unnecessary application restarts do not trigger other events.
             return
 
         # Emit an endpoints changed event if the database
@@ -3184,8 +3585,7 @@ class DatabaseRequirerEventHandlers(RequirerEventHandlers):
             # Emit the aliased event (if any).
             self._emit_aliased_event(event, "endpoints_changed")
 
-            # To avoid unnecessary application restarts do not trigger
-            # “read_only_endpoints_changed“ event if “endpoints_changed“ is triggered.
+            # To avoid unnecessary application restarts do not trigger other events.
             return
 
         # Emit a read only endpoints changed event if the database
@@ -3213,6 +3613,9 @@ class DatabaseRequires(DatabaseRequirerData, DatabaseRequirerEventHandlers):
         relations_aliases: Optional[List[str]] = None,
         additional_secret_fields: Optional[List[str]] = [],
         external_node_connectivity: bool = False,
+        extra_group_roles: Optional[str] = None,
+        entity_type: Optional[str] = None,
+        entity_permissions: Optional[str] = None,
     ):
         DatabaseRequirerData.__init__(
             self,
@@ -3223,6 +3626,9 @@ class DatabaseRequires(DatabaseRequirerData, DatabaseRequirerEventHandlers):
             relations_aliases,
             additional_secret_fields,
             external_node_connectivity,
+            extra_group_roles,
+            entity_type,
+            entity_permissions,
         )
         DatabaseRequirerEventHandlers.__init__(self, charm, self)
 
@@ -3234,7 +3640,7 @@ class DatabaseRequires(DatabaseRequirerData, DatabaseRequirerEventHandlers):
 # Kafka Events
 
 
-class KafkaProvidesEvent(RelationEvent):
+class KafkaProvidesEvent(RelationEventWithSecret):
     """Base class for Kafka events."""
 
     @property
@@ -3253,9 +3659,59 @@ class KafkaProvidesEvent(RelationEvent):
 
         return self.relation.data[self.relation.app].get("consumer-group-prefix")
 
+    @property
+    def mtls_cert(self) -> Optional[str]:
+        """Returns TLS cert of the client."""
+        if not self.relation.app:
+            return None
 
-class TopicRequestedEvent(KafkaProvidesEvent, ExtraRoleEvent):
+        if not self.secrets_enabled:
+            raise SecretsUnavailableError("Secrets unavailable on current Juju version")
+
+        secret_field = f"{PROV_SECRET_PREFIX}{SECRET_GROUPS.MTLS}"
+        if secret_uri := self.relation.data[self.app].get(secret_field):
+            secret = self.framework.model.get_secret(id=secret_uri)
+            content = secret.get_content(refresh=True)
+            if content:
+                return content.get("mtls-cert")
+
+
+class KafkaClientMtlsCertUpdatedEvent(KafkaProvidesEvent):
+    """Event emitted when the mtls relation is updated."""
+
+    def __init__(self, handle, relation, old_mtls_cert: Optional[str] = None, app=None, unit=None):
+        super().__init__(handle, relation, app, unit)
+
+        self.old_mtls_cert = old_mtls_cert
+
+    def snapshot(self):
+        """Return a snapshot of the event."""
+        return super().snapshot() | {"old_mtls_cert": self.old_mtls_cert}
+
+    def restore(self, snapshot):
+        """Restore the event from a snapshot."""
+        super().restore(snapshot)
+        self.old_mtls_cert = snapshot["old_mtls_cert"]
+
+
+class TopicRequestedEvent(KafkaProvidesEvent):
     """Event emitted when a new topic is requested for use on this relation."""
+
+    @property
+    def extra_user_roles(self) -> Optional[str]:
+        """Returns the extra user roles that were requested."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("extra-user-roles")
+
+
+class TopicEntityRequestedEvent(KafkaProvidesEvent, EntityProvidesEvent):
+    """Event emitted when a new entity is requested for use on this relation."""
+
+
+class TopicEntityPermissionsChangedEvent(KafkaProvidesEvent, EntityProvidesEvent):
+    """Event emitted when existing entity permissions are changed on this relation."""
 
 
 class KafkaProvidesEvents(CharmEvents):
@@ -3265,6 +3721,9 @@ class KafkaProvidesEvents(CharmEvents):
     """
 
     topic_requested = EventSource(TopicRequestedEvent)
+    topic_entity_requested = EventSource(TopicEntityRequestedEvent)
+    topic_entity_permissions_changed = EventSource(TopicEntityPermissionsChangedEvent)
+    mtls_cert_updated = EventSource(KafkaClientMtlsCertUpdatedEvent)
 
 
 class KafkaRequiresEvent(RelationEvent):
@@ -3307,6 +3766,10 @@ class TopicCreatedEvent(AuthenticationEvent, KafkaRequiresEvent):
     """Event emitted when a new topic is created for use on this relation."""
 
 
+class TopicEntityCreatedEvent(EntityRequiresEvent, KafkaRequiresEvent):
+    """Event emitted when a new entity is created for use on this relation."""
+
+
 class BootstrapServerChangedEvent(AuthenticationEvent, KafkaRequiresEvent):
     """Event emitted when the bootstrap server is changed."""
 
@@ -3318,6 +3781,7 @@ class KafkaRequiresEvents(CharmEvents):
     """
 
     topic_created = EventSource(TopicCreatedEvent)
+    topic_entity_created = EventSource(TopicEntityCreatedEvent)
     bootstrap_server_changed = EventSource(BootstrapServerChangedEvent)
 
 
@@ -3369,7 +3833,7 @@ class KafkaProviderData(ProviderData):
         self.update_relation_data(relation_id, {"zookeeper-uris": zookeeper_uris})
 
 
-class KafkaProviderEventHandlers(EventHandlers):
+class KafkaProviderEventHandlers(ProviderEventHandlers):
     """Provider-side of the Kafka relation."""
 
     on = KafkaProvidesEvents()  # pyright: ignore [reportAssignmentType]
@@ -3381,6 +3845,14 @@ class KafkaProviderEventHandlers(EventHandlers):
 
     def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
         """Event emitted when the relation has changed."""
+        super()._on_relation_changed_event(event)
+
+        new_data_keys = list(event.relation.data[event.app].keys())
+        if any(newval for newval in new_data_keys if self.relation_data._is_secret_field(newval)):
+            self.relation_data._register_secrets_to_relation(event.relation, new_data_keys)
+
+        getattr(self.on, "mtls_cert_updated").emit(event.relation, app=event.app, unit=event.unit)
+
         # Leader only
         if not self.relation_data.local_unit.is_leader():
             return
@@ -3388,12 +3860,69 @@ class KafkaProviderEventHandlers(EventHandlers):
         # Check which data has changed to emit customs events.
         diff = self._diff(event)
 
-        # Emit a topic requested event if the setup key (topic name and optional
-        # extra user roles) was added to the relation databag by the application.
-        if "topic" in diff.added:
+        # Validate entity information is not dynamically changed
+        self._validate_entity_consistency(event, diff)
+
+        # Emit a topic requested event if the setup key (topic name)
+        # was added to the relation databag, but the entity-type key was not.
+        if "topic" in diff.added and "entity-type" not in diff.added:
             getattr(self.on, "topic_requested").emit(
                 event.relation, app=event.app, unit=event.unit
             )
+
+            # To avoid unnecessary application restarts do not trigger other events.
+            return
+
+        # Emit an entity requested event if the setup key (topic name)
+        # was added to the relation databag, in addition to the entity-type key.
+        if "topic" in diff.added and "entity-type" in diff.added:
+            getattr(self.on, "topic_entity_requested").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+
+            # To avoid unnecessary application restarts do not trigger other events.
+            return
+
+        # Emit a permissions changed event if the setup key (topic name)
+        # was added to the relation databag, and the entity-permissions key changed.
+        if (
+            "topic" not in diff.added
+            and "entity-type" not in diff.added
+            and ("entity-permissions" in diff.added or "entity-permissions" in diff.changed)
+        ):
+            getattr(self.on, "topic_entity_permissions_changed").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+
+            # To avoid unnecessary application restarts do not trigger other events.
+            return
+
+    def _on_secret_changed_event(self, event: SecretChangedEvent):
+        """Event notifying about a new value of a secret."""
+        if not event.secret.label:
+            return
+
+        relation = self.relation_data._relation_from_secret_label(event.secret.label)
+        if not relation:
+            logging.info(
+                f"Received secret {event.secret.label} but couldn't parse, seems irrelevant"
+            )
+            return
+
+        if relation.app == self.charm.app:
+            logging.info("Secret changed event ignored for Secret Owner")
+
+        remote_unit = None
+        for unit in relation.units:
+            if unit.app != self.charm.app:
+                remote_unit = unit
+
+        old_mtls_cert = event.secret.get_content().get("mtls-cert")
+        # mtls-cert is the only secret that can be updated
+        logger.info("mtls-cert updated")
+        getattr(self.on, "mtls_cert_updated").emit(
+            relation, app=relation.app, unit=remote_unit, old_mtls_cert=old_mtls_cert
+        )
 
 
 class KafkaProvides(KafkaProviderData, KafkaProviderEventHandlers):
@@ -3415,11 +3944,29 @@ class KafkaRequirerData(RequirerData):
         extra_user_roles: Optional[str] = None,
         consumer_group_prefix: Optional[str] = None,
         additional_secret_fields: Optional[List[str]] = [],
+        mtls_cert: Optional[str] = None,
+        extra_group_roles: Optional[str] = None,
+        entity_type: Optional[str] = None,
+        entity_permissions: Optional[str] = None,
     ):
         """Manager of Kafka client relations."""
-        super().__init__(model, relation_name, extra_user_roles, additional_secret_fields)
+        super().__init__(
+            model,
+            relation_name,
+            extra_user_roles,
+            additional_secret_fields,
+            extra_group_roles,
+            entity_type,
+            entity_permissions,
+        )
         self.topic = topic
         self.consumer_group_prefix = consumer_group_prefix or ""
+        self.mtls_cert = mtls_cert
+
+    @staticmethod
+    def is_topic_value_acceptable(topic_value: str) -> bool:
+        """Check whether the given Kafka topic value is acceptable."""
+        return "*" not in topic_value[:3]
 
     @property
     def topic(self):
@@ -3428,10 +3975,18 @@ class KafkaRequirerData(RequirerData):
 
     @topic.setter
     def topic(self, value):
-        # Avoid wildcards
-        if value == "*":
-            raise ValueError(f"Error on topic '{value}', cannot be a wildcard.")
+        if not self.is_topic_value_acceptable(value):
+            raise ValueError(f"Error on topic '{value}', unacceptable value.")
         self._topic = value
+
+    def set_mtls_cert(self, relation_id: int, mtls_cert: str) -> None:
+        """Set the mtls cert in the application relation databag / secret.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            mtls_cert: mtls cert.
+        """
+        self.update_relation_data(relation_id, {"mtls-cert": mtls_cert})
 
 
 class KafkaRequirerEventHandlers(RequirerEventHandlers):
@@ -3454,11 +4009,20 @@ class KafkaRequirerEventHandlers(RequirerEventHandlers):
         # Sets topic, extra user roles, and "consumer-group-prefix" in the relation
         relation_data = {"topic": self.relation_data.topic}
 
-        if self.relation_data.extra_user_roles:
-            relation_data["extra-user-roles"] = self.relation_data.extra_user_roles
+        if self.relation_data.mtls_cert:
+            relation_data["mtls-cert"] = self.relation_data.mtls_cert
 
         if self.relation_data.consumer_group_prefix:
             relation_data["consumer-group-prefix"] = self.relation_data.consumer_group_prefix
+
+        if self.relation_data.extra_user_roles:
+            relation_data["extra-user-roles"] = self.relation_data.extra_user_roles
+        if self.relation_data.extra_group_roles:
+            relation_data["extra-group-roles"] = self.relation_data.extra_group_roles
+        if self.relation_data.entity_type:
+            relation_data["entity-type"] = self.relation_data.entity_type
+        if self.relation_data.entity_permissions:
+            relation_data["entity-permissions"] = self.relation_data.entity_permissions
 
         self.relation_data.update_relation_data(event.relation.id, relation_data)
 
@@ -3478,16 +4042,26 @@ class KafkaRequirerEventHandlers(RequirerEventHandlers):
         if any(newval for newval in diff.added if self.relation_data._is_secret_field(newval)):
             self.relation_data._register_secrets_to_relation(event.relation, diff.added)
 
-        secret_field_user = self.relation_data._generate_secret_field_name(SECRET_GROUPS.USER)
-        if (
-            "username" in diff.added and "password" in diff.added
-        ) or secret_field_user in diff.added:
+        app_databag = get_encoded_dict(event.relation, event.app, "data")
+        if app_databag is None:
+            app_databag = {}
+
+        if self._main_credentials_shared(diff) and "entity-type" not in app_databag:
             # Emit the default event (the one without an alias).
             logger.info("topic created at %s", datetime.now())
             getattr(self.on, "topic_created").emit(event.relation, app=event.app, unit=event.unit)
 
-            # To avoid unnecessary application restarts do not trigger
-            # “endpoints_changed“ event if “topic_created“ is triggered.
+            # To avoid unnecessary application restarts do not trigger other events.
+            return
+
+        if self._entity_credentials_shared(diff) and "entity-type" in app_databag:
+            # Emit the default event (the one without an alias).
+            logger.info("entity created at %s", datetime.now())
+            getattr(self.on, "topic_entity_created").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+
+            # To avoid unnecessary application restarts do not trigger other events.
             return
 
         # Emit an endpoints (bootstrap-server) changed event if the Kafka endpoints
@@ -3498,6 +4072,8 @@ class KafkaRequirerEventHandlers(RequirerEventHandlers):
             getattr(self.on, "bootstrap_server_changed").emit(
                 event.relation, app=event.app, unit=event.unit
             )  # here check if this is the right design
+
+            # To avoid unnecessary application restarts do not trigger other events.
             return
 
 
@@ -3512,17 +4088,366 @@ class KafkaRequires(KafkaRequirerData, KafkaRequirerEventHandlers):
         extra_user_roles: Optional[str] = None,
         consumer_group_prefix: Optional[str] = None,
         additional_secret_fields: Optional[List[str]] = [],
+        mtls_cert: Optional[str] = None,
+        extra_group_roles: Optional[str] = None,
+        entity_type: Optional[str] = None,
+        entity_permissions: Optional[str] = None,
     ) -> None:
         KafkaRequirerData.__init__(
             self,
             charm.model,
             relation_name,
             topic,
-            extra_user_roles,
-            consumer_group_prefix,
-            additional_secret_fields,
+            extra_user_roles=extra_user_roles,
+            consumer_group_prefix=consumer_group_prefix,
+            additional_secret_fields=additional_secret_fields,
+            mtls_cert=mtls_cert,
+            extra_group_roles=extra_group_roles,
+            entity_type=entity_type,
+            entity_permissions=entity_permissions,
         )
         KafkaRequirerEventHandlers.__init__(self, charm, self)
+
+
+# Karapace related events
+
+
+class KarapaceProvidesEvent(RelationEvent):
+    """Base class for Karapace events."""
+
+    @property
+    def subject(self) -> Optional[str]:
+        """Returns the subject that was requested."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("subject")
+
+
+class SubjectRequestedEvent(KarapaceProvidesEvent):
+    """Event emitted when a new subject is requested for use on this relation."""
+
+    @property
+    def extra_user_roles(self) -> Optional[str]:
+        """Returns the extra user roles that were requested."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("extra-user-roles")
+
+
+class SubjectEntityRequestedEvent(KarapaceProvidesEvent, EntityProvidesEvent):
+    """Event emitted when a new entity is requested for use on this relation."""
+
+
+class SubjectEntityPermissionsChangedEvent(KarapaceProvidesEvent, EntityProvidesEvent):
+    """Event emitted when existing entity permissions are changed on this relation."""
+
+
+class KarapaceProvidesEvents(CharmEvents):
+    """Karapace events.
+
+    This class defines the events that the Karapace can emit.
+    """
+
+    subject_requested = EventSource(SubjectRequestedEvent)
+    subject_entity_requested = EventSource(SubjectEntityRequestedEvent)
+    subject_entity_permissions_changed = EventSource(SubjectEntityPermissionsChangedEvent)
+
+
+class KarapaceRequiresEvent(RelationEvent):
+    """Base class for Karapace events."""
+
+    @property
+    def subject(self) -> Optional[str]:
+        """Returns the subject."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("subject")
+
+    @property
+    def endpoints(self) -> Optional[str]:
+        """Returns a comma-separated list of broker uris."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("endpoints")
+
+
+class SubjectAllowedEvent(AuthenticationEvent, KarapaceRequiresEvent):
+    """Event emitted when a new subject ACL is created for use on this relation."""
+
+
+class SubjectEntityCreatedEvent(EntityRequiresEvent, KarapaceRequiresEvent):
+    """Event emitted when a new entity is created for use on this relation."""
+
+
+class EndpointsChangedEvent(AuthenticationEvent, KarapaceRequiresEvent):
+    """Event emitted when the endpoints are changed."""
+
+
+class KarapaceRequiresEvents(CharmEvents):
+    """Karapace events.
+
+    This class defines the events that Karapace can emit.
+    """
+
+    subject_allowed = EventSource(SubjectAllowedEvent)
+    subject_entity_created = EventSource(SubjectEntityCreatedEvent)
+    server_changed = EventSource(EndpointsChangedEvent)
+
+
+# Karapace Provides and Requires
+
+
+class KarapaceProviderData(ProviderData):
+    """Provider-side of the Karapace relation."""
+
+    RESOURCE_FIELD = "subject"
+
+    def __init__(self, model: Model, relation_name: str) -> None:
+        super().__init__(model, relation_name)
+
+    def set_subject(self, relation_id: int, subject: str) -> None:
+        """Set subject name in the application relation databag.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            subject: the subject name.
+        """
+        self.update_relation_data(relation_id, {"subject": subject})
+
+    def set_endpoint(self, relation_id: int, endpoint: str) -> None:
+        """Set the endpoint in the application relation databag.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            endpoint: the server address.
+        """
+        self.update_relation_data(relation_id, {"endpoints": endpoint})
+
+
+class KarapaceProviderEventHandlers(ProviderEventHandlers):
+    """Provider-side of the Karapace relation."""
+
+    on = KarapaceProvidesEvents()  # pyright: ignore [reportAssignmentType]
+
+    def __init__(self, charm: CharmBase, relation_data: KarapaceProviderData) -> None:
+        super().__init__(charm, relation_data)
+        # Just to keep lint quiet, can't resolve inheritance. The same happened in super().__init__() above
+        self.relation_data = relation_data
+
+    def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
+        """Event emitted when the relation has changed."""
+        super()._on_relation_changed_event(event)
+
+        # Leader only
+        if not self.relation_data.local_unit.is_leader():
+            return
+
+        # Check which data has changed to emit customs events.
+        diff = self._diff(event)
+
+        # Validate entity information is not dynamically changed
+        self._validate_entity_consistency(event, diff)
+
+        # Emit a subject requested event if the setup key (subject name)
+        # was added to the relation databag, but the entity-type key was not.
+        if "subject" in diff.added and "entity-type" not in diff.added:
+            getattr(self.on, "subject_requested").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+
+            # To avoid unnecessary application restarts do not trigger other events.
+            return
+
+        # Emit an entity requested event if the setup key (subject name)
+        # was added to the relation databag, in addition to the entity-type key.
+        if "subject" in diff.added and "entity-type" in diff.added:
+            getattr(self.on, "subject_entity_requested").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+
+            # To avoid unnecessary application restarts do not trigger other events.
+            return
+
+        # Emit a permissions changed event if the setup key (subject name)
+        # was added to the relation databag, and the entity-permissions key changed.
+        if (
+            "subject" not in diff.added
+            and "entity-type" not in diff.added
+            and ("entity-permissions" in diff.added or "entity-permissions" in diff.changed)
+        ):
+            getattr(self.on, "subject_entity_permissions_changed").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+
+            # To avoid unnecessary application restarts do not trigger other events.
+            return
+
+    def _on_secret_changed_event(self, event: SecretChangedEvent):
+        """Event notifying about a new value of a secret."""
+        pass
+
+
+class KarapaceProvides(KarapaceProviderData, KarapaceProviderEventHandlers):
+    """Provider-side of the Karapace relation."""
+
+    def __init__(self, charm: CharmBase, relation_name: str) -> None:
+        KarapaceProviderData.__init__(self, charm.model, relation_name)
+        KarapaceProviderEventHandlers.__init__(self, charm, self)
+
+
+class KarapaceRequirerData(RequirerData):
+    """Requirer-side of the Karapace relation."""
+
+    def __init__(
+        self,
+        model: Model,
+        relation_name: str,
+        subject: str,
+        extra_user_roles: Optional[str] = None,
+        additional_secret_fields: Optional[List[str]] = [],
+        extra_group_roles: Optional[str] = None,
+        entity_type: Optional[str] = None,
+        entity_permissions: Optional[str] = None,
+    ):
+        """Manager of Karapace client relations."""
+        super().__init__(
+            model,
+            relation_name,
+            extra_user_roles,
+            additional_secret_fields,
+            extra_group_roles,
+            entity_type,
+            entity_permissions,
+        )
+        self.subject = subject
+
+    @property
+    def subject(self):
+        """Topic to use in Karapace."""
+        return self._subject
+
+    @subject.setter
+    def subject(self, value):
+        # Avoid wildcards
+        if value == "*":
+            raise ValueError(f"Error on subject '{value}', cannot be a wildcard.")
+        self._subject = value
+
+
+class KarapaceRequirerEventHandlers(RequirerEventHandlers):
+    """Requires-side of the Karapace relation."""
+
+    on = KarapaceRequiresEvents()  # pyright: ignore [reportAssignmentType]
+
+    def __init__(self, charm: CharmBase, relation_data: KarapaceRequirerData) -> None:
+        super().__init__(charm, relation_data)
+        # Just to keep lint quiet, can't resolve inheritance. The same happened in super().__init__() above
+        self.relation_data = relation_data
+
+    def _on_relation_created_event(self, event: RelationCreatedEvent) -> None:
+        """Event emitted when the Karapace relation is created."""
+        super()._on_relation_created_event(event)
+
+        if not self.relation_data.local_unit.is_leader():
+            return
+
+        # Sets subject and extra user roles
+        relation_data = {"subject": self.relation_data.subject}
+
+        if self.relation_data.extra_user_roles:
+            relation_data["extra-user-roles"] = self.relation_data.extra_user_roles
+        if self.relation_data.extra_group_roles:
+            relation_data["extra-group-roles"] = self.relation_data.extra_group_roles
+        if self.relation_data.entity_type:
+            relation_data["entity-type"] = self.relation_data.entity_type
+        if self.relation_data.entity_permissions:
+            relation_data["entity-permissions"] = self.relation_data.entity_permissions
+
+        self.relation_data.update_relation_data(event.relation.id, relation_data)
+
+    def _on_secret_changed_event(self, event: SecretChangedEvent):
+        """Event notifying about a new value of a secret."""
+        pass
+
+    def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
+        """Event emitted when the Karapace relation has changed."""
+        # Check which data has changed to emit customs events.
+        diff = self._diff(event)
+
+        # Check if the subject ACLs are created
+        # (the Karapace charm shared the credentials).
+
+        # Register all new secrets with their labels
+        if any(newval for newval in diff.added if self.relation_data._is_secret_field(newval)):
+            self.relation_data._register_secrets_to_relation(event.relation, diff.added)
+
+        app_databag = get_encoded_dict(event.relation, event.app, "data")
+        if app_databag is None:
+            app_databag = {}
+
+        if self._main_credentials_shared(diff) and "entity-type" not in app_databag:
+            # Emit the default event (the one without an alias).
+            logger.info("subject ACL created at %s", datetime.now())
+            getattr(self.on, "subject_allowed").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+
+            # To avoid unnecessary application restarts do not trigger other events.
+            return
+
+        if self._entity_credentials_shared(diff) and "entity-type" in app_databag:
+            # Emit the default event (the one without an alias).
+            logger.info("entity created at %s", datetime.now())
+            getattr(self.on, "subject_entity_created").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+
+            # To avoid unnecessary application restarts do not trigger other events.
+            return
+
+        # Emit an endpoints changed event if the Karapace endpoints added or changed
+        # this info in the relation databag.
+        if "endpoints" in diff.added or "endpoints" in diff.changed:
+            # Emit the default event (the one without an alias).
+            logger.info("endpoints changed on %s", datetime.now())
+            getattr(self.on, "server_changed").emit(
+                event.relation, app=event.app, unit=event.unit
+            )  # here check if this is the right design
+
+            # To avoid unnecessary application restarts do not trigger other events.
+            return
+
+
+class KarapaceRequires(KarapaceRequirerData, KarapaceRequirerEventHandlers):
+    """Provider-side of the Karapace relation."""
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        relation_name: str,
+        subject: str,
+        extra_user_roles: Optional[str] = None,
+        additional_secret_fields: Optional[List[str]] = [],
+        extra_group_roles: Optional[str] = None,
+        entity_type: Optional[str] = None,
+        entity_permissions: Optional[str] = None,
+    ) -> None:
+        KarapaceRequirerData.__init__(
+            self,
+            charm.model,
+            relation_name,
+            subject,
+            extra_user_roles,
+            additional_secret_fields,
+            extra_group_roles,
+            entity_type,
+            entity_permissions,
+        )
+        KarapaceRequirerEventHandlers.__init__(self, charm, self)
 
 
 # Opensearch related events
@@ -3540,8 +4465,24 @@ class OpenSearchProvidesEvent(RelationEvent):
         return self.relation.data[self.relation.app].get("index")
 
 
-class IndexRequestedEvent(OpenSearchProvidesEvent, ExtraRoleEvent):
+class IndexRequestedEvent(OpenSearchProvidesEvent):
     """Event emitted when a new index is requested for use on this relation."""
+
+    @property
+    def extra_user_roles(self) -> Optional[str]:
+        """Returns the extra user roles that were requested."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("extra-user-roles")
+
+
+class IndexEntityRequestedEvent(OpenSearchProvidesEvent, EntityProvidesEvent):
+    """Event emitted when a new entity is requested for use on this relation."""
+
+
+class IndexEntityPermissionsChangedEvent(OpenSearchProvidesEvent, EntityProvidesEvent):
+    """Event emitted when existing entity permissions are changed on this relation."""
 
 
 class OpenSearchProvidesEvents(CharmEvents):
@@ -3551,6 +4492,8 @@ class OpenSearchProvidesEvents(CharmEvents):
     """
 
     index_requested = EventSource(IndexRequestedEvent)
+    index_entity_requested = EventSource(IndexEntityRequestedEvent)
+    index_entity_permissions_changed = EventSource(IndexEntityPermissionsChangedEvent)
 
 
 class OpenSearchRequiresEvent(DatabaseRequiresEvent):
@@ -3561,6 +4504,10 @@ class IndexCreatedEvent(AuthenticationEvent, OpenSearchRequiresEvent):
     """Event emitted when a new index is created for use on this relation."""
 
 
+class IndexEntityCreatedEvent(EntityRequiresEvent, OpenSearchRequiresEvent):
+    """Event emitted when a new index is created for use on this relation."""
+
+
 class OpenSearchRequiresEvents(CharmEvents):
     """OpenSearch events.
 
@@ -3568,6 +4515,7 @@ class OpenSearchRequiresEvents(CharmEvents):
     """
 
     index_created = EventSource(IndexCreatedEvent)
+    index_entity_created = EventSource(IndexEntityCreatedEvent)
     endpoints_changed = EventSource(DatabaseEndpointsChangedEvent)
     authentication_updated = EventSource(AuthenticationEvent)
 
@@ -3613,7 +4561,7 @@ class OpenSearchProvidesData(ProviderData):
         self.update_relation_data(relation_id, {"version": version})
 
 
-class OpenSearchProvidesEventHandlers(EventHandlers):
+class OpenSearchProvidesEventHandlers(ProviderEventHandlers):
     """Provider-side of the OpenSearch relation."""
 
     on = OpenSearchProvidesEvents()  # pyright: ignore[reportAssignmentType]
@@ -3625,18 +4573,55 @@ class OpenSearchProvidesEventHandlers(EventHandlers):
 
     def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
         """Event emitted when the relation has changed."""
+        super()._on_relation_changed_event(event)
+
         # Leader only
         if not self.relation_data.local_unit.is_leader():
             return
+
         # Check which data has changed to emit customs events.
         diff = self._diff(event)
 
-        # Emit an index requested event if the setup key (index name and optional extra user roles)
-        # have been added to the relation databag by the application.
-        if "index" in diff.added:
+        # Validate entity information is not dynamically changed
+        self._validate_entity_consistency(event, diff)
+
+        # Emit an index requested event if the setup key (index name)
+        # was added to the relation databag, but the entity-type key was not.
+        if "index" in diff.added and "entity-type" not in diff.added:
             getattr(self.on, "index_requested").emit(
                 event.relation, app=event.app, unit=event.unit
             )
+
+            # To avoid unnecessary application restarts do not trigger other events.
+            return
+
+        # Emit an entity requested event if the setup key (index name)
+        # was added to the relation databag, in addition to the entity-type key.
+        if "index" in diff.added and "entity-type" in diff.added:
+            getattr(self.on, "index_entity_requested").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+
+            # To avoid unnecessary application restarts do not trigger other events.
+            return
+
+        # Emit a permissions changed event if the setup key (index name)
+        # was added to the relation databag, and the entity-permissions key changed.
+        if (
+            "index" not in diff.added
+            and "entity-type" not in diff.added
+            and ("entity-permissions" in diff.added or "entity-permissions" in diff.changed)
+        ):
+            getattr(self.on, "index_entity_permissions_changed").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+
+            # To avoid unnecessary application restarts do not trigger other events.
+            return
+
+    def _on_secret_changed_event(self, event: SecretChangedEvent) -> None:
+        """Event emitted when the relation data has changed."""
+        pass
 
 
 class OpenSearchProvides(OpenSearchProvidesData, OpenSearchProvidesEventHandlers):
@@ -3657,9 +4642,20 @@ class OpenSearchRequiresData(RequirerData):
         index: str,
         extra_user_roles: Optional[str] = None,
         additional_secret_fields: Optional[List[str]] = [],
+        extra_group_roles: Optional[str] = None,
+        entity_type: Optional[str] = None,
+        entity_permissions: Optional[str] = None,
     ):
         """Manager of OpenSearch client relations."""
-        super().__init__(model, relation_name, extra_user_roles, additional_secret_fields)
+        super().__init__(
+            model,
+            relation_name,
+            extra_user_roles,
+            additional_secret_fields,
+            extra_group_roles,
+            entity_type,
+            entity_permissions,
+        )
         self.index = index
 
 
@@ -3683,8 +4679,15 @@ class OpenSearchRequiresEventHandlers(RequirerEventHandlers):
         # Sets both index and extra user roles in the relation if the roles are provided.
         # Otherwise, sets only the index.
         data = {"index": self.relation_data.index}
+
         if self.relation_data.extra_user_roles:
             data["extra-user-roles"] = self.relation_data.extra_user_roles
+        if self.relation_data.extra_group_roles:
+            data["extra-group-roles"] = self.relation_data.extra_group_roles
+        if self.relation_data.entity_type:
+            data["entity-type"] = self.relation_data.entity_type
+        if self.relation_data.entity_permissions:
+            data["entity-permissions"] = self.relation_data.entity_permissions
 
         self.relation_data.update_relation_data(event.relation.id, data)
 
@@ -3734,27 +4737,40 @@ class OpenSearchRequiresEventHandlers(RequirerEventHandlers):
                 event.relation, app=event.app, unit=event.unit
             )
 
+        app_databag = get_encoded_dict(event.relation, event.app, "data")
+        if app_databag is None:
+            app_databag = {}
+
         # Check if the index is created
         # (the OpenSearch charm shares the credentials).
-        if (
-            "username" in diff.added and "password" in diff.added
-        ) or secret_field_user in diff.added:
+        if self._main_credentials_shared(diff) and "entity-type" not in app_databag:
             # Emit the default event (the one without an alias).
             logger.info("index created at: %s", datetime.now())
             getattr(self.on, "index_created").emit(event.relation, app=event.app, unit=event.unit)
 
-            # To avoid unnecessary application restarts do not trigger
-            # “endpoints_changed“ event if “index_created“ is triggered.
+            # To avoid unnecessary application restarts do not trigger other events.
             return
 
-        # Emit a endpoints changed event if the OpenSearch application added or changed this info
-        # in the relation databag.
+        if self._entity_credentials_shared(diff) and "entity-type" in app_databag:
+            # Emit the default event (the one without an alias).
+            logger.info("entity created at: %s", datetime.now())
+            getattr(self.on, "index_entity_created").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+
+            # To avoid unnecessary application restarts do not trigger other events.
+            return
+
+        # Emit a endpoints changed event if the OpenSearch application
+        # added or changed this info in the relation databag.
         if "endpoints" in diff.added or "endpoints" in diff.changed:
             # Emit the default event (the one without an alias).
             logger.info("endpoints changed on %s", datetime.now())
             getattr(self.on, "endpoints_changed").emit(
                 event.relation, app=event.app, unit=event.unit
-            )  # here check if this is the right design
+            )
+
+            # To avoid unnecessary application restarts do not trigger other events.
             return
 
 
@@ -3768,6 +4784,9 @@ class OpenSearchRequires(OpenSearchRequiresData, OpenSearchRequiresEventHandlers
         index: str,
         extra_user_roles: Optional[str] = None,
         additional_secret_fields: Optional[List[str]] = [],
+        extra_group_roles: Optional[str] = None,
+        entity_type: Optional[str] = None,
+        entity_permissions: Optional[str] = None,
     ) -> None:
         OpenSearchRequiresData.__init__(
             self,
@@ -3776,5 +4795,348 @@ class OpenSearchRequires(OpenSearchRequiresData, OpenSearchRequiresEventHandlers
             index,
             extra_user_roles,
             additional_secret_fields,
+            extra_group_roles,
+            entity_type,
+            entity_permissions,
         )
         OpenSearchRequiresEventHandlers.__init__(self, charm, self)
+
+
+# Etcd related events
+
+
+class EtcdProviderEvent(RelationEventWithSecret):
+    """Base class for Etcd events."""
+
+    @property
+    def prefix(self) -> Optional[str]:
+        """Returns the index that was requested."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("prefix")
+
+    @property
+    def mtls_cert(self) -> Optional[str]:
+        """Returns TLS cert of the client."""
+        if not self.relation.app:
+            return None
+
+        if not self.secrets_enabled:
+            raise SecretsUnavailableError("Secrets unavailable on current Juju version")
+
+        secret_field = f"{PROV_SECRET_PREFIX}{SECRET_GROUPS.MTLS}"
+        if secret_uri := self.relation.data[self.app].get(secret_field):
+            secret = self.framework.model.get_secret(id=secret_uri)
+            content = secret.get_content(refresh=True)
+            if content:
+                return content.get("mtls-cert")
+
+
+class MTLSCertUpdatedEvent(EtcdProviderEvent):
+    """Event emitted when the mtls relation is updated."""
+
+    def __init__(self, handle, relation, old_mtls_cert: Optional[str] = None, app=None, unit=None):
+        super().__init__(handle, relation, app, unit)
+
+        self.old_mtls_cert = old_mtls_cert
+
+    def snapshot(self):
+        """Return a snapshot of the event."""
+        return super().snapshot() | {"old_mtls_cert": self.old_mtls_cert}
+
+    def restore(self, snapshot):
+        """Restore the event from a snapshot."""
+        super().restore(snapshot)
+        self.old_mtls_cert = snapshot["old_mtls_cert"]
+
+
+class EtcdProviderEvents(CharmEvents):
+    """Etcd events.
+
+    This class defines the events that Etcd can emit.
+    """
+
+    mtls_cert_updated = EventSource(MTLSCertUpdatedEvent)
+
+
+class EtcdReadyEvent(AuthenticationEvent, DatabaseRequiresEvent):
+    """Event emitted when the etcd relation is ready to be consumed."""
+
+
+class EtcdRequirerEvents(CharmEvents):
+    """Etcd events.
+
+    This class defines the events that the etcd requirer can emit.
+    """
+
+    endpoints_changed = EventSource(DatabaseEndpointsChangedEvent)
+    etcd_ready = EventSource(EtcdReadyEvent)
+
+
+# Etcd Provides and Requires Objects
+
+
+class EtcdProviderData(ProviderData):
+    """Provider-side of the Etcd relation."""
+
+    RESOURCE_FIELD = "prefix"
+
+    def __init__(self, model: Model, relation_name: str) -> None:
+        super().__init__(model, relation_name)
+
+    def set_uris(self, relation_id: int, uris: str) -> None:
+        """Set the database connection URIs in the application relation databag.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            uris: connection URIs.
+        """
+        self.update_relation_data(relation_id, {"uris": uris})
+
+    def set_endpoints(self, relation_id: int, endpoints: str) -> None:
+        """Set the endpoints in the application relation databag.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            endpoints: the endpoint addresses for etcd nodes "ip:port" format.
+        """
+        self.update_relation_data(relation_id, {"endpoints": endpoints})
+
+    def set_version(self, relation_id: int, version: str) -> None:
+        """Set the etcd version in the application relation databag.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            version: etcd API version.
+        """
+        self.update_relation_data(relation_id, {"version": version})
+
+    def set_tls_ca(self, relation_id: int, tls_ca: str) -> None:
+        """Set the TLS CA in the application relation databag.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            tls_ca: TLS certification authority.
+        """
+        self.update_relation_data(relation_id, {"tls-ca": tls_ca, "tls": "True"})
+
+
+class EtcdProviderEventHandlers(ProviderEventHandlers):
+    """Provider-side of the Etcd relation."""
+
+    on = EtcdProviderEvents()  # pyright: ignore[reportAssignmentType]
+
+    def __init__(self, charm: CharmBase, relation_data: EtcdProviderData) -> None:
+        super().__init__(charm, relation_data)
+        # Just to keep lint quiet, can't resolve inheritance. The same happened in super().__init__() above
+        self.relation_data = relation_data
+
+    def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
+        """Event emitted when the relation has changed."""
+        super()._on_relation_changed_event(event)
+        # register all new secrets with their labels
+        new_data_keys = list(event.relation.data[event.app].keys())
+        if any(newval for newval in new_data_keys if self.relation_data._is_secret_field(newval)):
+            self.relation_data._register_secrets_to_relation(event.relation, new_data_keys)
+
+        # Check which data has changed to emit customs events.
+        diff = self._diff(event)
+
+        # Validate entity information is not dynamically changed
+        self._validate_entity_consistency(event, diff)
+
+        getattr(self.on, "mtls_cert_updated").emit(event.relation, app=event.app, unit=event.unit)
+        return
+
+    def _on_secret_changed_event(self, event: SecretChangedEvent):
+        """Event notifying about a new value of a secret."""
+        if not event.secret.label:
+            return
+
+        relation = self.relation_data._relation_from_secret_label(event.secret.label)
+        if not relation:
+            logging.info(
+                f"Received secret {event.secret.label} but couldn't parse, seems irrelevant"
+            )
+            return
+
+        if relation.app == self.charm.app:
+            logging.info("Secret changed event ignored for Secret Owner")
+
+        remote_unit = None
+        for unit in relation.units:
+            if unit.app != self.charm.app:
+                remote_unit = unit
+
+        old_mtls_cert = event.secret.get_content().get("mtls-cert")
+        # mtls-cert is the only secret that can be updated
+        logger.info("mtls-cert updated")
+        getattr(self.on, "mtls_cert_updated").emit(
+            relation, app=relation.app, unit=remote_unit, old_mtls_cert=old_mtls_cert
+        )
+
+
+class EtcdProvides(EtcdProviderData, EtcdProviderEventHandlers):
+    """Provider-side of the Etcd relation."""
+
+    def __init__(self, charm: CharmBase, relation_name: str) -> None:
+        EtcdProviderData.__init__(self, charm.model, relation_name)
+        EtcdProviderEventHandlers.__init__(self, charm, self)
+        if not self.secrets_enabled:
+            raise SecretsUnavailableError("Secrets unavailable on current Juju version")
+
+
+class EtcdRequirerData(RequirerData):
+    """Requires data side of the Etcd relation."""
+
+    def __init__(
+        self,
+        model: Model,
+        relation_name: str,
+        prefix: str,
+        mtls_cert: Optional[str],
+        extra_user_roles: Optional[str] = None,
+        additional_secret_fields: Optional[List[str]] = [],
+        extra_group_roles: Optional[str] = None,
+        entity_type: Optional[str] = None,
+        entity_permissions: Optional[str] = None,
+    ):
+        """Manager of Etcd client relations."""
+        super().__init__(
+            model,
+            relation_name,
+            extra_user_roles,
+            additional_secret_fields,
+            extra_group_roles,
+            entity_type,
+            entity_permissions,
+        )
+        self.prefix = prefix
+        self.mtls_cert = mtls_cert
+
+    def set_mtls_cert(self, relation_id: int, mtls_cert: str) -> None:
+        """Set the mtls cert in the application relation databag / secret.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            mtls_cert: mtls cert.
+        """
+        self.update_relation_data(relation_id, {"mtls-cert": mtls_cert})
+
+
+class EtcdRequirerEventHandlers(RequirerEventHandlers):
+    """Requires events side of the Etcd relation."""
+
+    on = EtcdRequirerEvents()  # pyright: ignore[reportAssignmentType]
+
+    def __init__(self, charm: CharmBase, relation_data: EtcdRequirerData) -> None:
+        super().__init__(charm, relation_data)
+        # Just to keep lint quiet, can't resolve inheritance. The same happened in super().__init__() above
+        self.relation_data = relation_data
+
+    def _on_relation_created_event(self, event: RelationCreatedEvent) -> None:
+        """Event emitted when the Etcd relation is created."""
+        super()._on_relation_created_event(event)
+
+        payload = {
+            "prefix": self.relation_data.prefix,
+        }
+        if self.relation_data.mtls_cert:
+            payload["mtls-cert"] = self.relation_data.mtls_cert
+
+        self.relation_data.update_relation_data(
+            event.relation.id,
+            payload,
+        )
+
+    def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
+        """Event emitted when the Etcd relation has changed.
+
+        This event triggers individual custom events depending on the changing relation.
+        """
+        # Check which data has changed to emit customs events.
+        diff = self._diff(event)
+        # Register all new secrets with their labels
+        if any(newval for newval in diff.added if self.relation_data._is_secret_field(newval)):
+            self.relation_data._register_secrets_to_relation(event.relation, diff.added)
+
+        secret_field_user = self.relation_data._generate_secret_field_name(SECRET_GROUPS.USER)
+        secret_field_tls = self.relation_data._generate_secret_field_name(SECRET_GROUPS.TLS)
+
+        # Emit a endpoints changed event if the etcd application added or changed this info
+        # in the relation databag.
+        if "endpoints" in diff.added or "endpoints" in diff.changed:
+            # Emit the default event (the one without an alias).
+            logger.info("endpoints changed on %s", datetime.now())
+            getattr(self.on, "endpoints_changed").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+
+        if (
+            secret_field_tls in diff.added
+            or secret_field_tls in diff.changed
+            or secret_field_user in diff.added
+            or secret_field_user in diff.changed
+            or "username" in diff.added
+            or "username" in diff.changed
+        ):
+            # Emit the default event (the one without an alias).
+            logger.info("etcd ready on %s", datetime.now())
+            getattr(self.on, "etcd_ready").emit(event.relation, app=event.app, unit=event.unit)
+
+    def _on_secret_changed_event(self, event: SecretChangedEvent):
+        """Event notifying about a new value of a secret."""
+        if not event.secret.label:
+            return
+
+        relation = self.relation_data._relation_from_secret_label(event.secret.label)
+        if not relation:
+            logging.info(
+                f"Received secret {event.secret.label} but couldn't parse, seems irrelevant"
+            )
+            return
+
+        if relation.app == self.charm.app:
+            logging.info("Secret changed event ignored for Secret Owner")
+
+        remote_unit = None
+        for unit in relation.units:
+            if unit.app != self.charm.app:
+                remote_unit = unit
+
+        # secret-user or secret-tls updated
+        logger.info("etcd_ready updated")
+        getattr(self.on, "etcd_ready").emit(relation, app=relation.app, unit=remote_unit)
+
+
+class EtcdRequires(EtcdRequirerData, EtcdRequirerEventHandlers):
+    """Requires-side of the Etcd relation."""
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        relation_name: str,
+        prefix: str,
+        mtls_cert: Optional[str],
+        extra_user_roles: Optional[str] = None,
+        additional_secret_fields: Optional[List[str]] = [],
+        extra_group_roles: Optional[str] = None,
+        entity_type: Optional[str] = None,
+        entity_permissions: Optional[str] = None,
+    ) -> None:
+        EtcdRequirerData.__init__(
+            self,
+            charm.model,
+            relation_name,
+            prefix,
+            mtls_cert,
+            extra_user_roles,
+            additional_secret_fields,
+            extra_group_roles,
+            entity_type,
+            entity_permissions,
+        )
+        EtcdRequirerEventHandlers.__init__(self, charm, self)
+        if not self.secrets_enabled:
+            raise SecretsUnavailableError("Secrets unavailable on current Juju version")

--- a/src/services.py
+++ b/src/services.py
@@ -332,9 +332,11 @@ class FrontendService(AbstractService):
         # Set up proxies if needed.
         # Ref: https://datahubproject.io/docs/authentication/guides/sso/configure-oidc-behind-proxy/  # noqa
         proxy_vars = {}
-        no_proxy_hosts = {"localhost"}
+        no_proxy_hosts = []
+        if os.getenv("JUJU_CHARM_NO_PROXY"):
+            no_proxy_hosts = str(os.getenv("JUJU_CHARM_NO_PROXY")).split(",")
         if env.get("DATAHUB_GMS_HOST"):
-            no_proxy_hosts.add(env["DATAHUB_GMS_HOST"])
+            no_proxy_hosts.append(env["DATAHUB_GMS_HOST"])
 
         if http_proxy_raw := os.getenv("JUJU_CHARM_HTTP_PROXY"):
             http_proxy = urlparse(http_proxy_raw)
@@ -345,7 +347,6 @@ class FrontendService(AbstractService):
             proxy_vars["HTTPS_PROXY_HOST"] = https_proxy.hostname
             proxy_vars["HTTPS_PROXY_PORT"] = str(https_proxy.port or "")
 
-        # TODO (mertalpt): Figure out a way to integrate model no proxy hosts into the charm.
         proxy_vars["HTTP_NON_PROXY_HOSTS"] = "|".join(no_proxy_hosts)
         env.update(proxy_vars)
 

--- a/src/services.py
+++ b/src/services.py
@@ -333,8 +333,8 @@ class FrontendService(AbstractService):
         # Ref: https://datahubproject.io/docs/authentication/guides/sso/configure-oidc-behind-proxy/  # noqa
         proxy_vars = {}
         no_proxy_hosts = {"localhost"}
-        # if os.getenv("JUJU_CHARM_NO_PROXY"):
-        # no_proxy_hosts.extend(str(os.getenv("JUJU_CHARM_NO_PROXY")).split(","))
+        if os.getenv("JUJU_CHARM_NO_PROXY"):
+            no_proxy_hosts.extend(str(os.getenv("JUJU_CHARM_NO_PROXY")).split(","))
         if env.get("DATAHUB_GMS_HOST"):
             no_proxy_hosts.add(env["DATAHUB_GMS_HOST"])
 

--- a/src/services.py
+++ b/src/services.py
@@ -332,9 +332,9 @@ class FrontendService(AbstractService):
         # Set up proxies if needed.
         # Ref: https://datahubproject.io/docs/authentication/guides/sso/configure-oidc-behind-proxy/  # noqa
         proxy_vars = {}
-        no_proxy_hosts = []
+        no_proxy_hosts = ["localhost"]
         if os.getenv("JUJU_CHARM_NO_PROXY"):
-            no_proxy_hosts = str(os.getenv("JUJU_CHARM_NO_PROXY")).split(",")
+            no_proxy_hosts.extend(str(os.getenv("JUJU_CHARM_NO_PROXY")).split(","))
         if env.get("DATAHUB_GMS_HOST"):
             no_proxy_hosts.append(env["DATAHUB_GMS_HOST"])
 

--- a/src/services.py
+++ b/src/services.py
@@ -332,11 +332,11 @@ class FrontendService(AbstractService):
         # Set up proxies if needed.
         # Ref: https://datahubproject.io/docs/authentication/guides/sso/configure-oidc-behind-proxy/  # noqa
         proxy_vars = {}
-        no_proxy_hosts = {"localhost"}
+        no_proxy_hosts = ["localhost"]
         if os.getenv("JUJU_CHARM_NO_PROXY"):
             no_proxy_hosts.extend(str(os.getenv("JUJU_CHARM_NO_PROXY")).split(","))
         if env.get("DATAHUB_GMS_HOST"):
-            no_proxy_hosts.add(env["DATAHUB_GMS_HOST"])
+            no_proxy_hosts.extend(env["DATAHUB_GMS_HOST"])
 
         if http_proxy_raw := os.getenv("JUJU_CHARM_HTTP_PROXY"):
             http_proxy = urlparse(http_proxy_raw)

--- a/src/services.py
+++ b/src/services.py
@@ -290,6 +290,7 @@ class FrontendService(AbstractService):
         frontend_secret_key = encryption_secret.get_content(refresh=True)["frontend-key"]
 
         env = {
+            "AUTH_VERBOSE_LOGGING": context.charm.config.auth_verbose_logging,
             # TODO (mertalpt): To be implemented with to o11y update.
             "ENABLE_PROMETHEUS": "false",
             # TODO (mertalpt): This changes when we split services into multiple charms.

--- a/src/services.py
+++ b/src/services.py
@@ -332,11 +332,11 @@ class FrontendService(AbstractService):
         # Set up proxies if needed.
         # Ref: https://datahubproject.io/docs/authentication/guides/sso/configure-oidc-behind-proxy/  # noqa
         proxy_vars = {}
-        no_proxy_hosts = ["localhost"]
-        if os.getenv("JUJU_CHARM_NO_PROXY"):
-            no_proxy_hosts.extend(str(os.getenv("JUJU_CHARM_NO_PROXY")).split(","))
+        no_proxy_hosts = {"localhost"}
+        # if os.getenv("JUJU_CHARM_NO_PROXY"):
+        # no_proxy_hosts.extend(str(os.getenv("JUJU_CHARM_NO_PROXY")).split(","))
         if env.get("DATAHUB_GMS_HOST"):
-            no_proxy_hosts.append(env["DATAHUB_GMS_HOST"])
+            no_proxy_hosts.add(env["DATAHUB_GMS_HOST"])
 
         if http_proxy_raw := os.getenv("JUJU_CHARM_HTTP_PROXY"):
             http_proxy = urlparse(http_proxy_raw)

--- a/src/structured_config.py
+++ b/src/structured_config.py
@@ -16,6 +16,7 @@ class CharmConfig(BaseConfigModel):
     """Manager for the structured configuration.
 
     Attributes:
+        auth_verbose_logging: Enables verbose authentication logging.
         encryption_keys_secret_id: Juju secret ID to use for secret keys.
         use_play_cache_session_store: Flag to determine if Play cache will be used for
             session store instead of having browser based OIDC cookies.
@@ -27,6 +28,7 @@ class CharmConfig(BaseConfigModel):
         tls_secret_name: Name of the k8s secret to use for the TLS certificate.
     """
 
+    auth_verbose_logging: bool = False
     encryption_keys_secret_id: str
     use_play_cache_session_store: bool
     oidc_secret_id: Optional[str] = None

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -30,17 +30,22 @@ RESOURCES = {item: METADATA["resources"][item]["upstream-source"] for item in RE
 
 KAFKA_NAME = "kafka"
 KAFKA_CHANNEL = "3/stable"
+KAFKA_REVISION = 195
 KAFKA_OFFER_NAME = "kafka-client"
 OPENSEARCH_NAME = "opensearch"
 OPENSEARCH_CHANNEL = "2/stable"
+OPENSEARCH_REVISION = 168
 OPENSEARCH_OFFER_NAME = "os-client"
 POSTGRES_NAME = "postgresql"
 POSTGRES_CHANNEL = "14/stable"
+POSTGRES_REVISION = 553
 POSTGRES_OFFER_NAME = "pg-client"
 CERTIFICATES_NAME = "self-signed-certificates"
 CERTIFICATES_CHANNEL = "latest/stable"
+CERTIFICATES_REVISION = 264
 ZOOKEPER_NAME = "zookeeper"
 ZOOKEEPER_CHANNEL = "3/stable"
+ZOOKEEPER_REVISION = 149
 INGRESS_NAME = "nginx-ingress-integrator"
 INGRESS_CHANNEL = "stable"
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -154,11 +154,26 @@ class TestDeployment:
                 # Deploy dependencies
                 logger.info("Deploying LXD dependencies")
                 await asyncio.gather(
-                    ops_test.model.deploy(helpers.KAFKA_NAME, channel=helpers.KAFKA_CHANNEL),
-                    ops_test.model.deploy(helpers.OPENSEARCH_NAME, channel=helpers.OPENSEARCH_CHANNEL, num_units=2),
-                    ops_test.model.deploy(helpers.POSTGRES_NAME, channel=helpers.POSTGRES_CHANNEL),
-                    ops_test.model.deploy(helpers.CERTIFICATES_NAME, channel=helpers.CERTIFICATES_CHANNEL),
-                    ops_test.model.deploy(helpers.ZOOKEPER_NAME, channel=helpers.ZOOKEEPER_CHANNEL),
+                    ops_test.model.deploy(
+                        helpers.KAFKA_NAME, channel=helpers.KAFKA_CHANNEL, revision=helpers.KAFKA_REVISION
+                    ),
+                    ops_test.model.deploy(
+                        helpers.OPENSEARCH_NAME,
+                        channel=helpers.OPENSEARCH_CHANNEL,
+                        num_units=2,
+                        revision=helpers.OPENSEARCH_REVISION,
+                    ),
+                    ops_test.model.deploy(
+                        helpers.POSTGRES_NAME, channel=helpers.POSTGRES_CHANNEL, revision=helpers.POSTGRES_REVISION
+                    ),
+                    ops_test.model.deploy(
+                        helpers.CERTIFICATES_NAME,
+                        channel=helpers.CERTIFICATES_CHANNEL,
+                        revision=helpers.CERTIFICATES_REVISION,
+                    ),
+                    ops_test.model.deploy(
+                        helpers.ZOOKEPER_NAME, channel=helpers.ZOOKEEPER_CHANNEL, revision=helpers.ZOOKEEPER_REVISION
+                    ),
                 )
 
                 # Wait for the dependencies to settle


### PR DESCRIPTION
## Description

This PR adds an additional config parameter that enables verbose logs for the frontend service, as well as picking up the no_proxy config from the model.