### PR TITLE
prevent image upload

### DIFF
--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -28,3 +28,4 @@ jobs:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           channel: "latest/edge"
+          upload-image: false

--- a/src/services.py
+++ b/src/services.py
@@ -504,6 +504,7 @@ class GMSService(AbstractService):
         gms_secret_key = encryption_secret.get_content(refresh=True)["gms-key"]
 
         env = {
+            "THEME_V2_DEFAULT": "true",
             "DATAHUB_TELEMETRY_ENABLED": "false",
             "EBEAN_DATASOURCE_PORT": db_conn["port"],
             "SHOW_SEARCH_FILTERS_V2": "true",
@@ -1213,8 +1214,17 @@ class UpgradeService(AbstractService):
         Returns:
             If reindexing was run and was successful.
         """
-        logger.info("Running reindexing using datahub-upgrade")
         container = context.charm.unit.get_container(cls.name)
+
+        logger.info("Pushing runner script for datahub-upgrade")
+        utils.push_file(
+            container,
+            literals.RUNNER_SRC_PATH,
+            literals.RUNNER_DEST_PATH,
+            0o755,
+        )
+
+        logger.info("Running reindexing using datahub-upgrade")
         environment = cls.compile_environment(context)
         command = [
             literals.RUNNER_DEST_PATH,


### PR DESCRIPTION
## Description

This PR:

- Adds the `THEME_V2_DEFAULT` environment variable to the `GMS` container as well, as it is needed there too apparently.
- Pushes the runner script to the `datahub-upgrade` container before running the `reindex` action.
- Prevents images from being uploaded to Charmhub when publishing the charm. This is because we need to customize the `datahub-actions` image to include the `trino` and `acryl-datahub[trino]` packages in [CSS-16895](https://warthogs.atlassian.net/browse/CSS-16895), and this ends up overwriting them. This will no longer be necessary once we move to rock images.
