### PR TITLE
feat: propagate proxy variables to DataHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,11 +126,30 @@ client-secret: <client-secret-value>
 11. Deploy DataHub with the added config variable `--config oidc-secret-id=<secret-id>`.
 12. Run `juju grant-secret <secret-name> datahub-k8s` to set permissions.
 13. Proceed with the relations.
-14. If your deployment is behind a HTTP proxy, set it on your Juju model via
+14. If your deployment is behind an HTTP proxy, configure model proxies as described in [Configuring Model Proxies](#configuring-model-proxies).
+
+### Configuring Model Proxies
+
+If your model runs in a restricted network, configure Juju model proxies so DataHub
+containers can reach external services (for example Python package indexes).
+
 ```sh
-juju model-config juju-http-proxy=<http-proxy-address>
-juju model-config juju-https-proxy=<http-proxy-address>
+juju model-config juju-http-proxy=http://proxy.example:8080
+juju model-config juju-https-proxy=http://proxy.example:8080
+juju model-config juju-no-proxy=127.0.0.1,localhost,.svc,.cluster.local
 ```
+
+Proxy propagation behavior in this charm:
+- `datahub-actions` receives standard proxy variables (`HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY` and lowercase variants), which are used by Python tooling.
+- `datahub-frontend` receives its existing JVM proxy settings.
+
+To verify proxy variables on a container:
+
+```sh
+kubectl -n <namespace> exec -c <datahub-actions|datahub-frontend> datahub-k8s-0 -- pebble plan | grep -i '_proxy\|proxy'
+```
+
+After changing model proxy settings, allow one `update-status` cycle or trigger a new hook event (for example a config change) so the charm can refresh Pebble plans.
 
 ### Migrating Data
 

--- a/src/services.py
+++ b/src/services.py
@@ -20,7 +20,7 @@ import abc
 import logging
 import os
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Dict, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional
 from urllib.parse import urlparse
 
 import exceptions
@@ -113,6 +113,50 @@ def _kafka_topic_names(prefix: str) -> Dict[str, str]:
 
     names = {k: f"{prefix}_{v}" for (k, v) in default_names.items()}
     return names
+
+
+def _compile_standard_proxy_environment(extra_no_proxy_hosts: Optional[List[str]] = None) -> Dict[str, str]:
+    """Compile standard proxy variables from Juju charm proxy environment variables.
+
+    Args:
+        extra_no_proxy_hosts: Optional hostnames to append to NO_PROXY/no_proxy.
+
+    Returns:
+        Standard proxy variables suitable for Python tools.
+    """
+    proxy_vars: Dict[str, str] = {}
+    proxy_map = {
+        "JUJU_CHARM_HTTP_PROXY": ("HTTP_PROXY", "http_proxy"),
+        "JUJU_CHARM_HTTPS_PROXY": ("HTTPS_PROXY", "https_proxy"),
+    }
+
+    has_proxy_config = False
+    for juju_var, target_vars in proxy_map.items():
+        value = os.getenv(juju_var)
+        if not value:
+            continue
+        has_proxy_config = True
+        for target in target_vars:
+            proxy_vars[target] = value
+
+    juju_no_proxy = os.getenv("JUJU_CHARM_NO_PROXY")
+    if juju_no_proxy:
+        has_proxy_config = True
+
+    if has_proxy_config:
+        no_proxy_values: List[str] = []
+        if juju_no_proxy:
+            no_proxy_values.extend(host.strip() for host in juju_no_proxy.split(",") if host.strip())
+        if extra_no_proxy_hosts:
+            no_proxy_values.extend(host.strip() for host in extra_no_proxy_hosts if host and host.strip())
+
+        if no_proxy_values:
+            unique_no_proxy = list(dict.fromkeys(no_proxy_values))
+            no_proxy = ",".join(unique_no_proxy)
+            proxy_vars["NO_PROXY"] = no_proxy
+            proxy_vars["no_proxy"] = no_proxy
+
+    return proxy_vars
 
 
 @dataclass
@@ -275,6 +319,7 @@ class ActionsService(AbstractService):
         }
         kafka_env = _kafka_topic_names(context.charm.config.kafka_topic_prefix)
         env.update(kafka_env)
+        env.update(_compile_standard_proxy_environment(extra_no_proxy_hosts=["localhost", env["DATAHUB_GMS_HOST"]]))
         return env
 
 

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -1,0 +1,91 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Unit tests for services.py."""
+
+import os
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import services
+
+
+def test_compile_standard_proxy_environment():
+    """Compile standard proxy variables from Juju proxy environment."""
+    with patch.dict(
+        os.environ,
+        {
+            "JUJU_CHARM_HTTP_PROXY": "http://proxy.example:8080",
+            "JUJU_CHARM_HTTPS_PROXY": "http://proxy.example:8443",
+            "JUJU_CHARM_NO_PROXY": "10.0.0.1,svc.cluster.local",
+        },
+        clear=True,
+    ):
+        env = services._compile_standard_proxy_environment(
+            extra_no_proxy_hosts=["localhost", "localhost", "datahub-gms"]
+        )
+
+    assert env["HTTP_PROXY"] == "http://proxy.example:8080"
+    assert env["http_proxy"] == "http://proxy.example:8080"
+    assert env["HTTPS_PROXY"] == "http://proxy.example:8443"
+    assert env["https_proxy"] == "http://proxy.example:8443"
+    assert env["NO_PROXY"] == "10.0.0.1,svc.cluster.local,localhost,datahub-gms"
+    assert env["no_proxy"] == "10.0.0.1,svc.cluster.local,localhost,datahub-gms"
+
+
+def test_actions_compile_environment_includes_proxy_vars():
+    """Actions environment should include standard proxy variables."""
+    state = SimpleNamespace(
+        kafka_connection={
+            "bootstrap_server": "kafka:9092",
+            "username": "user",
+            "password": "pass",  # nosec
+        }
+    )
+    config = SimpleNamespace(kafka_topic_prefix="")
+    context = services.ServiceContext(charm=SimpleNamespace(_state=state, config=config))
+
+    with patch.object(services.ActionsService, "is_enabled", return_value=True):
+        with patch.dict(
+            os.environ,
+            {
+                "JUJU_CHARM_HTTP_PROXY": "http://proxy.example:8080",
+                "JUJU_CHARM_HTTPS_PROXY": "http://proxy.example:8443",
+                "JUJU_CHARM_NO_PROXY": "10.0.0.1",
+            },
+            clear=True,
+        ):
+            env = services.ActionsService.compile_environment(context)
+
+    assert env is not None
+    assert env["HTTP_PROXY"] == "http://proxy.example:8080"
+    assert env["http_proxy"] == "http://proxy.example:8080"
+    assert env["HTTPS_PROXY"] == "http://proxy.example:8443"
+    assert env["https_proxy"] == "http://proxy.example:8443"
+    assert env["NO_PROXY"] == "10.0.0.1,localhost"
+    assert env["no_proxy"] == "10.0.0.1,localhost"
+
+
+def test_actions_compile_environment_omits_proxy_vars_when_unset():
+    """Actions environment should not include proxy variables when model proxy is unset."""
+    state = SimpleNamespace(
+        kafka_connection={
+            "bootstrap_server": "kafka:9092",
+            "username": "user",
+            "password": "pass",  # nosec
+        }
+    )
+    config = SimpleNamespace(kafka_topic_prefix="")
+    context = services.ServiceContext(charm=SimpleNamespace(_state=state, config=config))
+
+    with patch.object(services.ActionsService, "is_enabled", return_value=True):
+        with patch.dict(os.environ, {}, clear=True):
+            env = services.ActionsService.compile_environment(context)
+
+    assert env is not None
+    assert "HTTP_PROXY" not in env
+    assert "HTTPS_PROXY" not in env
+    assert "NO_PROXY" not in env
+    assert "http_proxy" not in env
+    assert "https_proxy" not in env
+    assert "no_proxy" not in env


### PR DESCRIPTION
## Description

The staging deployment has shown that ingestions do not run because PyPI is unreachable when creating virtual environments. This PR propagates Juju model proxy configurations to the Actions container to address this issue.

## Engineering checklist
_Check only items that apply_

- [x] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests
- [x] Independent change*

 _* This is an independent change if it can be merged and released independently without any related service deployments._

## Merging instructions

The preferred way of merging:
- [ ] Merge
- [ ] Squash and Merge
- [x] Rebase and Merge

## Notes for code reviewers

I have not tested these changes as it would take quite the setup to have a firewall and proxy. I will be testing it on staging. It is not ideal but production is stable and we can break staging until we fix it.
