### PR TITLE
fix: increase upgrade timeout

### DIFF
--- a/src/services.py
+++ b/src/services.py
@@ -871,7 +871,7 @@ class GMSService(AbstractService):
                 ],
                 encoding="utf-8",
                 environment=environment,
-                timeout=180,
+                timeout=600,
             )
             process.wait_output()
         except Exception as e:


### PR DESCRIPTION
## Description

The old timeout for `datahub-upgrade` worked for every environment except a crowded production environment. We increase it to allow it to work there too.

## Engineering checklist
_Check only items that apply_

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Independent change*

 _* This is an independent change if it can be merged and released independently without any related service deployments._

## Merging instructions

The preferred way of merging:
- [ ] Merge
- [ ] Squash and Merge
- [x] Rebase and Merge

## Notes for code reviewers

This is a non-destructive change that was tested on production.
