### PR TITLE
feat: implemented a trino relation

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,15 +213,23 @@ juju config datahub-k8s trino-patterns='{"schema-pattern":{"allow":[".*"],"deny"
 
 The option is a string for a JSON object that allows setting up allow and deny patterns for each of schema, table, and views.
 
-The DataHub charm will manage the following for the ingestions:
-- Access tokens
-- Trino host and port
-- Trino catalog name
-- HTTP/S proxy variables set via the model config
-- Default patterns set for the initial creation
-- Random schedule set for the initial creation
+The charm creates one ingestion source per Trino catalog with names prefixed by `[juju]`.
 
-Everything else can be updated and the charm will not interfere with the changes.
+On every reconciliation (triggered by relation changes), the charm will overwrite the following fields in each managed ingestion source:
+- Access tokens (stored as DataHub secrets)
+- Trino credentials (username and password, stored as DataHub secrets)
+- Trino host, port, and catalog name
+- HTTP/S proxy variables derived from the model config
+
+The following are set only during the initial creation of an ingestion source and preserved on subsequent updates:
+- Filter patterns from the `trino-patterns` config option
+- A random daily schedule (between 22:00 and 06:00 UTC)
+
+Because patterns are only applied on creation, they can be freely customized via the DataHub UI afterwards. To change the default patterns used for new ingestion sources, update the `trino-patterns` charm config.
+
+The schedule, description, executor, and any non-managed extra arguments can be freely updated via the DataHub UI without interference from the charm.
+
+When a catalog is removed from the Trino relation, its corresponding ingestion source is automatically deleted. When the relation is fully broken, all Juju-managed ingestion sources are cleaned up.
 
 ### Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -231,6 +231,16 @@ The schedule, description, executor, and any non-managed extra arguments can be 
 
 When a catalog is removed from the Trino relation, its corresponding ingestion source is automatically deleted. When the relation is fully broken, all Juju-managed ingestion sources are cleaned up. Note that cleaning the ingestions does not remove already ingested metadata.
 
+#### Managed Resource Naming Conventions
+
+The charm creates the following resources in DataHub, identifiable by their naming patterns:
+
+- **Ingestion sources**: Named `[juju] <catalog-name>-ingestion` (e.g. `[juju] sales-ingestion`).
+- **Per-catalog password secrets**: Named `JUJU_MANAGED_TRINO_PASSWORD_<NORMALIZED_CATALOG>`, where the catalog name is uppercased and non-alphanumeric characters are replaced with `_` (e.g. catalog `my-catalog.test` becomes `JUJU_MANAGED_TRINO_PASSWORD_MY_CATALOG_TEST`).
+- **GMS access token secret**: Named `JUJU_MANAGED_GMS_TOKEN`.
+
+When a catalog is removed or the Trino relation is broken, the corresponding ingestion sources and secrets are automatically deleted. User-created secrets and ingestion sources are not affected if they do not match the charm conventions.
+
 ### Troubleshooting
 
 - **Opensearch offer blocked**: If the Opensearch offer is blocked from the provider end, DataHub will load but some functionalities such as `Ingestion` will not work. This is best identified by requests to `/graphql` returning a `500` error. Ensure the offer is accepted on the provider side.

--- a/README.md
+++ b/README.md
@@ -196,6 +196,33 @@ juju config datahub-k8s tls-secret-name=<k8s-tls-secret-name>
 
 Alternatively, you can use the [Lego](https://charmhub.io/lego) charm to automate certificate management via ACME providers such as Let's Encrypt.
 
+### Integrating to Trino
+
+The DataHub charm supports a relation to the [Trino charm](https://charmhub.io/trino-k8s). The relation allows Datahub to fetch Trino catalogs and set up scheduled metadata ingestions for each catalog.
+
+Set up as follows:
+```sh
+juju deploy trino-k8s --channel latest/edge
+juju relate datahub-k8s trino-k8s
+```
+
+There is a configuration option to set up default patterns for metadata ingestions:
+```sh
+juju config datahub-k8s trino-patterns='{"schema-pattern":{"allow":[".*"],"deny":[]},"table-pattern":{"allow":[".*"],"deny":[]},"view-pattern":{"allow":[".*"],"deny":[]}}'
+```
+
+The option is a string for a JSON object that allows setting up allow and deny patterns for each of schema, table, and views.
+
+The DataHub charm will manage the following for the ingestions:
+- Access tokens
+- Trino host and port
+- Trino catalog name
+- HTTP/S proxy variables set via the model config
+- Default patterns set for the initial creation
+- Random schedule set for the initial creation
+
+Everything else can be updated and the charm will not interfere with the changes.
+
 ### Troubleshooting
 
 - **Opensearch offer blocked**: If the Opensearch offer is blocked from the provider end, DataHub will load but some functionalities such as `Ingestion` will not work. This is best identified by requests to `/graphql` returning a `500` error. Ensure the offer is accepted on the provider side.

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ Because patterns are only applied on creation, they can be freely customized via
 
 The schedule, description, executor, and any non-managed extra arguments can be freely updated via the DataHub UI without interference from the charm.
 
-When a catalog is removed from the Trino relation, its corresponding ingestion source is automatically deleted. When the relation is fully broken, all Juju-managed ingestion sources are cleaned up.
+When a catalog is removed from the Trino relation, its corresponding ingestion source is automatically deleted. When the relation is fully broken, all Juju-managed ingestion sources are cleaned up. Note that cleaning the ingestions does not remove already ingested metadata.
 
 ### Troubleshooting
 

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -136,26 +136,14 @@ config:
       type: boolean
       default: false
 
-    schema-pattern:
+    trino-patterns:
       description: |
-        JSON string for the schema pattern used for Trino ingestions.
-        Must be a JSON object with "allow" and "deny" lists of regex patterns.
+        JSON object containing schema, table, and view filter patterns for
+        Trino ingestion sources.  Each key ("schema-pattern", "table-pattern",
+        "view-pattern") maps to an object with "allow" and "deny" lists of
+        regex patterns.
       type: string
-      default: '{"allow":[".*"],"deny":[]}'
-
-    table-pattern:
-      description: |
-        JSON string for the table pattern used for Trino ingestions.
-        Must be a JSON object with "allow" and "deny" lists of regex patterns.
-      type: string
-      default: '{"allow":[".*"],"deny":[]}'
-
-    column-pattern:
-      description: |
-        JSON string for the column pattern used for Trino ingestions.
-        Must be a JSON object with "allow" and "deny" lists of regex patterns.
-      type: string
-      default: '{"allow":[".*"],"deny":[]}'
+      default: '{"schema-pattern":{"allow":[".*"],"deny":[]},"table-pattern":{"allow":[".*"],"deny":[]},"view-pattern":{"allow":[".*"],"deny":[]}}'
 
 actions:
   get-password:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -43,6 +43,8 @@ charm-libs:
     version: "0"
   - lib: nginx_ingress_integrator.nginx_route
     version: "0"
+  - lib: trino_k8s.trino_catalog
+    version: "0"
 
 parts:
   charm:
@@ -82,6 +84,10 @@ requires:
 
   nginx-gms-route:
     interface: nginx-route
+    limit: 1
+
+  trino-catalog:
+    interface: trino_catalog
     limit: 1
 
 config:
@@ -129,6 +135,27 @@ config:
         unsupported for horizontally scaled deployments.
       type: boolean
       default: false
+
+    schema-pattern:
+      description: |
+        JSON string for the schema pattern used for Trino ingestions.
+        Must be a JSON object with "allow" and "deny" lists of regex patterns.
+      type: string
+      default: '{"allow":[".*"],"deny":[]}'
+
+    table-pattern:
+      description: |
+        JSON string for the table pattern used for Trino ingestions.
+        Must be a JSON object with "allow" and "deny" lists of regex patterns.
+      type: string
+      default: '{"allow":[".*"],"deny":[]}'
+
+    column-pattern:
+      description: |
+        JSON string for the column pattern used for Trino ingestions.
+        Must be a JSON object with "allow" and "deny" lists of regex patterns.
+      type: string
+      default: '{"allow":[".*"],"deny":[]}'
 
 actions:
   get-password:

--- a/datahub_rocks/actions/files/executor.yaml
+++ b/datahub_rocks/actions/files/executor.yaml
@@ -44,4 +44,4 @@ action:
 datahub:
   server: "${DATAHUB_GMS_PROTOCOL}://${DATAHUB_GMS_HOST}:${DATAHUB_GMS_PORT}"
   extra_headers:
-    Authorization: "Basic ${DATAHUB_SYSTEM_CLIENT_ID:-__datahub_system}:${DATAHUB_SYSTEM_CLIENT_SECRET:-JohnSnowKnowsNothing}"
+    Authorization: "Basic ${DATAHUB_SYSTEM_CLIENT_ID:?DATAHUB_SYSTEM_CLIENT_ID must be set}:${DATAHUB_SYSTEM_CLIENT_SECRET:?DATAHUB_SYSTEM_CLIENT_SECRET must be set}"

--- a/lib/charms/trino_k8s/v0/trino_catalog.py
+++ b/lib/charms/trino_k8s/v0/trino_catalog.py
@@ -1,0 +1,317 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Library for the trino_catalog relation.
+
+This library provides the TrinoCatalogProvider and TrinoCatalogRequirer classes that
+handle the provider and the requirer sides of the trino_catalog interface.
+"""
+
+import json
+import logging
+from typing import List, Optional
+
+from ops.charm import CharmBase
+from ops.framework import Object
+from ops.model import ModelError, SecretNotFoundError
+
+# The unique Charmhub library identifier, never change it
+LIBID = "8855efa80c9a407991dafe157a762305"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 5
+
+
+
+logger = logging.getLogger(__name__)
+
+
+class TrinoCatalog:
+    """Represents a Trino catalog."""
+
+    def __init__(self, name: str, connector: str = "", description: str = ""):
+        """Initialize a TrinoCatalog.
+
+        Args:
+            name: Catalog name (e.g., "marketing", "sales")
+            connector: Optional connector type (e.g., "postgresql", "mysql", "bigquery")
+            description: Optional description of the catalog
+        """
+        self.name = name
+        self.connector = connector
+        self.description = description
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for serialization.
+
+        Returns:
+            Dictionary with name, connector, and description keys
+        """
+        return {
+            "name": self.name,
+            "connector": self.connector,
+            "description": self.description,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "TrinoCatalog":
+        """Create TrinoCatalog from dictionary.
+
+        Args:
+            data: Dictionary with name, optional connector, and optional description
+
+        Returns:
+            TrinoCatalog instance
+        """
+        return cls(
+            name=data["name"],
+            connector=data.get("connector", ""),
+            description=data.get("description", ""),
+        )
+
+    def __repr__(self) -> str:
+        """String representation for debugging.
+
+        Returns:
+            String representation of the TrinoCatalog object.
+        """
+        return f"TrinoCatalog(name={self.name}, connector={self.connector}, description={self.description})"
+
+    def __eq__(self, other) -> bool:
+        """Compare two catalogs for equality.
+
+        Args:
+            other: Object to compare with.
+
+        Returns:
+            True if catalogs are equal, False otherwise.
+        """
+        if not isinstance(other, TrinoCatalog):
+            return False
+        return (
+            self.name == other.name
+            and self.connector == other.connector
+            and self.description == other.description
+        )
+
+
+class TrinoCatalogProvider(Object):
+    """Provider side of the trino_catalog relation.
+
+    This library handles the relation lifecycle and data updates.
+    The charm is responsible for providing the actual data (url, catalogs, secret).
+    """
+
+    def __init__(self, charm: CharmBase, relation_name: str = "trino-catalog"):
+        """Initialize the TrinoCatalogProvider.
+
+        Args:
+            charm: The charm instance.
+            relation_name: Name of the relation.
+        """
+        super().__init__(charm, relation_name)
+        self.charm = charm
+        self.relation_name = relation_name
+
+    def update_relation_data(
+        self,
+        relation,
+        trino_url: str,
+        trino_catalogs: List[TrinoCatalog],
+        trino_credentials_secret_id: str,
+    ) -> bool:
+        """Update relation data for a specific relation.
+
+        Args:
+            relation: The relation to update
+            trino_url: Trino URL (e.g., "trino.example.com:443")
+            trino_catalogs: List of TrinoCatalog objects
+            trino_credentials_secret_id: Juju secret ID containing Trino users
+
+        Returns:
+            True if successful, False otherwise
+        """
+        logger.info("Updating trino-catalog relation %s", relation)
+
+        if not trino_url:
+            logger.debug("Trino URL not provided, skipping relation update")
+            return False
+
+        if not trino_credentials_secret_id:
+            logger.debug(
+                "Trino credentials secret ID not provided, skipping relation update"
+            )
+            return False
+
+        # Get current values from databag
+        current_data = relation.data[self.charm.app]
+        current_url = current_data.get("trino_url")
+        current_catalogs_str = current_data.get("trino_catalogs")
+        current_secret_id = current_data.get("trino_credentials_secret_id")
+
+        # Get new values
+        new_url = trino_url
+        try:
+            new_catalogs_str = json.dumps(
+                sorted(
+                    [c.to_dict() for c in trino_catalogs],
+                    key=lambda x: x["name"],
+                )
+            )
+        except (TypeError, KeyError) as e:
+            logger.error(
+                "Failed to serialize catalogs for relation %s: %s",
+                relation.id,
+                str(e),
+            )
+            return False
+
+        new_secret_id = trino_credentials_secret_id
+
+        # Detect changes
+        url_changed = current_url != new_url
+        catalogs_changed = current_catalogs_str != new_catalogs_str
+        secret_id_changed = current_secret_id != new_secret_id
+
+        # If nothing changed, skip update
+        if not (url_changed or catalogs_changed or secret_id_changed):
+            logger.debug(
+                "No changes for relation %s, skipping update", relation.id
+            )
+            return True
+
+        # Update relation databag
+        relation.data[self.charm.app].update(
+            {
+                "trino_url": new_url,
+                "trino_catalogs": new_catalogs_str,
+                "trino_credentials_secret_id": new_secret_id,
+            }
+        )
+
+        # Log what changed
+        changes = []
+        if url_changed:
+            changes.append("URL")
+        if catalogs_changed:
+            changes.append("catalogs")
+        if secret_id_changed:
+            changes.append("credentials")
+
+        logger.info(
+            "Updated trino-catalog relation %s: %s changed",
+            relation.id,
+            ", ".join(changes),
+        )
+        return True
+
+
+class TrinoCatalogRequirer(Object):
+    """Requirer side of the trino_catalog relation."""
+
+    def __init__(self, charm: CharmBase, relation_name: str = "trino-catalog"):
+        """Initialize the TrinoCatalogRequirer.
+
+        Args:
+            charm: The charm instance.
+            relation_name: Name of the relation.
+        """
+        super().__init__(charm, relation_name)
+        self.charm = charm
+        self.relation_name = relation_name
+
+        self.framework.observe(
+            charm.on[relation_name].relation_created,
+            self._on_relation_created,
+        )
+
+    def _on_relation_created(self, event) -> None:
+        """Publish app name so the provider can build a readable username."""
+        if not self.charm.unit.is_leader():
+            return
+        event.relation.data[self.charm.app]["app_name"] = self.charm.app.name
+
+    def get_trino_info(self) -> Optional[dict]:
+        """Get current Trino connection information.
+
+        Returns:
+            Dictionary with trino_url, trino_catalogs (List[TrinoCatalog]),
+            and trino_credentials_secret_id, or None if not available.
+        """
+        relations = self.charm.model.relations.get(self.relation_name, [])
+        if not relations:
+            return None
+
+        relation = relations[0]
+        if not relation.app:
+            return None
+
+        relation_data = relation.data[relation.app]
+
+        trino_url = relation_data.get("trino_url")
+        trino_catalogs_str = relation_data.get("trino_catalogs")
+        trino_credentials_secret_id = relation_data.get(
+            "trino_credentials_secret_id"
+        )
+
+        if not all(
+            [trino_url, trino_catalogs_str, trino_credentials_secret_id]
+        ):
+            return None
+
+        try:
+            catalogs_list = json.loads(trino_catalogs_str)
+            trino_catalogs = [TrinoCatalog.from_dict(c) for c in catalogs_list]
+        except (json.JSONDecodeError, KeyError):
+            return None
+
+        return {
+            "trino_url": trino_url,
+            "trino_catalogs": trino_catalogs,
+            "trino_credentials_secret_id": trino_credentials_secret_id,
+        }
+
+    def get_credentials(self) -> Optional[tuple]:
+        """Get Trino credentials from the per-relation secret.
+
+        Returns:
+            Tuple of (username, password) or None if not available.
+
+        Raises:
+            SecretNotFoundError: If the secret does not exist.
+            ModelError: If permission is denied to access the secret.
+        """
+        trino_info = self.get_trino_info()
+        if not trino_info:
+            return None
+
+        try:
+            secret = self.charm.model.get_secret(
+                id=trino_info["trino_credentials_secret_id"]
+            )
+            credentials = secret.get_content(refresh=True)
+        except SecretNotFoundError:
+            logger.error(
+                "Secret '%s' not found.",
+                trino_info["trino_credentials_secret_id"],
+            )
+            raise
+        except ModelError as e:
+            logger.error(
+                "Failed to access secret '%s': %s",
+                trino_info["trino_credentials_secret_id"],
+                str(e),
+            )
+            raise
+
+        username = credentials.get("username")
+        password = credentials.get("password")
+        if not username or not password:
+            logger.error("Secret missing username or password fields.")
+            return None
+
+        return (username, password)

--- a/src/charm.py
+++ b/src/charm.py
@@ -275,6 +275,7 @@ class DatahubK8SOperatorCharm(TypedCharmBase[CharmConfig]):
             event: The event triggered when the configuration is changed.
         """
         self.unit.status = ops.WaitingStatus("configuring application")
+        self._reconcile_trino_if_ready()
         self._update(event)
 
     @log_event_handler(logger)
@@ -303,7 +304,7 @@ class DatahubK8SOperatorCharm(TypedCharmBase[CharmConfig]):
         self._update(event)
 
     @log_event_handler(logger)
-    def _on_update_status(self, event):  # noqa C901
+    def _on_update_status(self, event):  # noqa C901  # pylint: disable=R0915
         """Handle `update-status` events.
 
         Args:
@@ -364,7 +365,21 @@ class DatahubK8SOperatorCharm(TypedCharmBase[CharmConfig]):
             logger.info("services down, exiting to wait for the next update")
             self.unit.status = ops.MaintenanceStatus("status check: DOWN")
         else:
+            self._reconcile_trino_if_ready()
             self.unit.status = ops.ActiveStatus()
+
+    def _reconcile_trino_if_ready(self):
+        """Run Trino ingestion reconciliation if preconditions are met."""
+        if not self.unit.is_leader():
+            return
+        if not self._state.is_ready():
+            return
+        if not self.model.get_relation("trino-catalog"):
+            return
+        try:
+            self.trino_relation._reconcile_ingestions()
+        except Exception as e:
+            logger.error("Trino reconciliation failed: %s", str(e))
 
     def _check_state(self):
         """Check the current state of the relations and overall charm readiness.

--- a/src/charm.py
+++ b/src/charm.py
@@ -4,6 +4,7 @@
 
 """Charm the application."""
 
+import json
 import logging
 import secrets
 from typing import Dict, List, Type, Union
@@ -115,9 +116,6 @@ class DatahubK8SOperatorCharm(TypedCharmBase[CharmConfig]):
         super().__init__(framework)
         self._state = State(self.app, lambda: self.model.get_relation("peer"))
 
-        # DataHub system client credentials (used for programmatic API access).
-        self._system_client_id = literals.SYSTEM_CLIENT_ID
-
         # Services
         for service in SERVICES:
             self.framework.observe(self.on[service.name].pebble_ready, self._on_pebble_ready)
@@ -159,7 +157,7 @@ class DatahubK8SOperatorCharm(TypedCharmBase[CharmConfig]):
     @property
     def system_client_id(self) -> str:
         """Return the DataHub system client identifier."""
-        return self._system_client_id
+        return literals.SYSTEM_CLIENT_ID
 
     @property
     def system_client_secret(self) -> str:
@@ -377,7 +375,7 @@ class DatahubK8SOperatorCharm(TypedCharmBase[CharmConfig]):
         if not self.model.get_relation("trino-catalog"):
             return
         try:
-            self.trino_relation._reconcile_ingestions()
+            self.trino_relation.reconcile_ingestions()
         except Exception as e:
             logger.error("Trino reconciliation failed: %s", str(e))
 
@@ -432,6 +430,15 @@ class DatahubK8SOperatorCharm(TypedCharmBase[CharmConfig]):
             err = f"missing required relation(s): {', '.join(missing_relations)}"
             raise exceptions.UnreadyStateError(err)
 
+        # Validate trino-patterns config is well-formed JSON mapping.
+        # This is to be moved to a Pydantic validation if we switch to that.
+        try:
+            parsed = json.loads(self.config.trino_patterns)
+        except (json.JSONDecodeError, TypeError) as e:
+            raise exceptions.UnreadyStateError(f"invalid 'trino-patterns' config: {e}") from None
+        if not isinstance(parsed, dict):
+            raise exceptions.UnreadyStateError("invalid 'trino-patterns' config: must be a JSON object")
+
     def _get_password(self):
         """Return the existing admin password, or None if it has not been generated yet."""
         relation = self.model.get_relation("peer")
@@ -443,7 +450,7 @@ class DatahubK8SOperatorCharm(TypedCharmBase[CharmConfig]):
             return None
 
         secret = self.model.get_secret(id=secret_id)
-        return secret.peek_content().get("password") or None
+        return secret.get_content(refresh=True).get("password") or None
 
     def _ensure_password(self):
         """Return the admin password, generating one on the leader if it does not exist yet."""
@@ -469,10 +476,10 @@ class DatahubK8SOperatorCharm(TypedCharmBase[CharmConfig]):
         if not relation:
             return ""
 
-        secret_id = relation.data[self.app].get(literals.SYSTEM_CLIENT_SECRET_LABEL, None)
+        secret_id = relation.data[self.app].get(literals.SYSTEM_CLIENT_SECRET_LABEL)
         if secret_id:
             secret = self.model.get_secret(id=secret_id)
-            return secret.peek_content().get("secret")
+            return secret.get_content(refresh=True).get("secret") or ""
 
         if self.unit.is_leader():
             content = {"secret": utils.generate_secret(64)}

--- a/src/charm.py
+++ b/src/charm.py
@@ -116,7 +116,7 @@ class DatahubK8SOperatorCharm(TypedCharmBase[CharmConfig]):
         self._state = State(self.app, lambda: self.model.get_relation("peer"))
 
         # DataHub system client credentials (used for programmatic API access).
-        self._system_client_id = "__datahub_system"
+        self._system_client_id = literals.SYSTEM_CLIENT_ID
 
         # Services
         for service in SERVICES:

--- a/src/charm.py
+++ b/src/charm.py
@@ -10,7 +10,6 @@ import secrets
 from typing import Dict, List, Type, Union
 
 import ops
-import yaml
 from charms.data_platform_libs.v0.data_interfaces import (
     DatabaseRequires,
     KafkaRequires,
@@ -18,7 +17,7 @@ from charms.data_platform_libs.v0.data_interfaces import (
 )
 from charms.data_platform_libs.v0.data_models import TypedCharmBase
 from charms.nginx_ingress_integrator.v0.nginx_route import require_nginx_route
-from ops.pebble import CheckStatus, PathError
+from ops.pebble import CheckStatus
 
 import exceptions
 import literals
@@ -181,35 +180,12 @@ class DatahubK8SOperatorCharm(TypedCharmBase[CharmConfig]):
         Args:
             event: Event instance being handled.
         """
-        # Frontend service requires a file to be present at startup.
         if event.workload.name == services.FrontendService.name:
+            self._state.frontend_user_props_initialized = False
             self._state.frontend_truststore_initialized = False
-            password = self._ensure_password()
-            if not password:
-                logger.info("could not generate admin password, will defer frontend initialization")
-                event.defer()
-            logger.debug("initial admin password generation successful")
-            utils.push_contents_to_file(
-                event.workload,
-                f"datahub:{password}",
-                "/datahub-frontend/conf/user.props",
-                0o644,
-            )
         if event.workload.name == services.GMSService.name:
+            self._state.gms_workload_version_set = False
             self._state.gms_truststore_initialized = False
-            try:
-                container = self.unit.get_container(services.GMSService.name)
-                if not container.can_connect():
-                    raise ValueError(f"Cannot connect to {services.GMSService.name}")
-                meta_file = container.pull("/rockcraft.yaml")
-                meta = yaml.safe_load(meta_file)
-                if meta and "version" in meta:
-                    self.unit.set_workload_version(meta["version"])
-                else:
-                    raise ValueError("Cannot find 'version' in 'rockcraft.yaml'.")
-            except (ops.ModelError, PathError, ValueError, yaml.YAMLError) as e:
-                logger.info("Could not get workload version: %s", str(e))
-                event.defer()
 
         self._update(event)
 
@@ -537,8 +513,7 @@ class DatahubK8SOperatorCharm(TypedCharmBase[CharmConfig]):
             for service in SERVICES:
                 container = self.unit.get_container(service.name)
                 if not container.can_connect():
-                    logger.info("Cannot connect to service '%s', deferring initialization", service.name)
-                    event.defer()
+                    logger.info("Cannot connect to service '%s', skipping initialization", service.name)
                     return
                 service.run_initialization(context)
         except Exception as e:
@@ -551,8 +526,7 @@ class DatahubK8SOperatorCharm(TypedCharmBase[CharmConfig]):
         for service in SERVICES:
             container = self.unit.get_container(service.name)
             if not container.can_connect():
-                logger.info("Cannot connect to service '%s', deferring replan", service.name)
-                event.defer()
+                logger.info("Cannot connect to service '%s', skipping replan", service.name)
                 return
 
             pebble_layer = get_pebble_layer(service, context)

--- a/src/charm.py
+++ b/src/charm.py
@@ -27,6 +27,7 @@ from log import log_event_handler
 from relations.kafka import KafkaRelation
 from relations.opensearch import OpenSearchRelation
 from relations.postgresql import PostgresqlRelation
+from relations.trino import TrinoRelation
 from state import State
 from structured_config import CharmConfig
 
@@ -99,6 +100,8 @@ class DatahubK8SOperatorCharm(TypedCharmBase[CharmConfig]):
         config_type: Class used to store the config.
         external_fe_hostname: Property for the hostname of the frontend visible to outside.
         external_gms_hostname: Property for the hostname of the GMS visible to outside.
+        system_client_id: The DataHub system client identifier for API auth.
+        system_client_secret: The DataHub system client secret for API auth.
     """
 
     config_type = CharmConfig
@@ -111,6 +114,9 @@ class DatahubK8SOperatorCharm(TypedCharmBase[CharmConfig]):
         """
         super().__init__(framework)
         self._state = State(self.app, lambda: self.model.get_relation("peer"))
+
+        # DataHub system client credentials (used for programmatic API access).
+        self._system_client_id = "__datahub_system"
 
         # Services
         for service in SERVICES:
@@ -144,8 +150,21 @@ class DatahubK8SOperatorCharm(TypedCharmBase[CharmConfig]):
         )
         self.opensearch_relation = OpenSearchRelation(self)
 
+        # Trino
+        self.trino_relation = TrinoRelation(self)
+
         # Ingress
         self._require_nginx_route()
+
+    @property
+    def system_client_id(self) -> str:
+        """Return the DataHub system client identifier."""
+        return self._system_client_id
+
+    @property
+    def system_client_secret(self) -> str:
+        """Return the DataHub system client secret."""
+        return self._get_or_create_system_client_secret()
 
     @property
     def external_fe_hostname(self):
@@ -426,6 +445,25 @@ class DatahubK8SOperatorCharm(TypedCharmBase[CharmConfig]):
             secret = self.app.add_secret(content, label=literals.INIT_PWD_SECRET_LABEL)
             relation.data[self.app][literals.INIT_PWD_SECRET_LABEL] = secret.id
             return content["password"]
+
+        return ""
+
+    def _get_or_create_system_client_secret(self):
+        """Return the system client secret, creating it on the leader if it does not exist."""
+        relation = self.model.get_relation("peer")
+        if not relation:
+            return ""
+
+        secret_id = relation.data[self.app].get(literals.SYSTEM_CLIENT_SECRET_LABEL, None)
+        if secret_id:
+            secret = self.model.get_secret(id=secret_id)
+            return secret.peek_content().get("secret")
+
+        if self.unit.is_leader():
+            content = {"secret": utils.generate_secret(64)}
+            secret = self.app.add_secret(content, label=literals.SYSTEM_CLIENT_SECRET_LABEL)
+            relation.data[self.app][literals.SYSTEM_CLIENT_SECRET_LABEL] = secret.id
+            return content["secret"]
 
         return ""
 

--- a/src/graphql.py
+++ b/src/graphql.py
@@ -82,7 +82,7 @@ def create_access_token(system_client_id: str, system_client_secret: str) -> str
     variables = {
         "input": {
             "type": "PERSONAL",
-            "actorUrn": "urn:li:corpuser:__datahub_system",
+            "actorUrn": f"urn:li:corpuser:{literals.SYSTEM_CLIENT_ID}",
             "duration": "NO_EXPIRY",
             "name": "juju-managed-ingestion-token",
         }

--- a/src/graphql.py
+++ b/src/graphql.py
@@ -116,12 +116,13 @@ def list_secrets(bearer_token: str) -> Dict[str, str]:
     secrets: Dict[str, str] = {}
 
     while True:
+        prev_size = len(secrets)
         variables = {"input": {"start": start, "count": count}}
         body = _graphql_request(query, variables, bearer_token)
         data = body["data"]["listSecrets"]
         for secret in data.get("secrets", []):
             secrets[secret["name"]] = secret["urn"]
-        if len(secrets) >= data["total"]:
+        if len(secrets) >= data["total"] or len(secrets) == prev_size:
             break
         start += count
 
@@ -208,12 +209,13 @@ def list_ingestion_sources(bearer_token: str) -> List[Dict[str, Any]]:
     all_sources: List[Dict[str, Any]] = []
 
     while True:
+        prev_size = len(all_sources)
         variables = {"input": {"start": start, "count": count}}
         body = _graphql_request(query, variables, bearer_token)
         data = body["data"]["listIngestionSources"]
         sources = data.get("ingestionSources", [])
         all_sources.extend(sources)
-        if len(all_sources) >= data["total"]:
+        if len(all_sources) >= data["total"] or len(all_sources) == prev_size:
             break
         start += count
 

--- a/src/graphql.py
+++ b/src/graphql.py
@@ -276,3 +276,17 @@ def delete_ingestion_source(bearer_token: str, urn: str) -> None:
             deleteIngestionSource(urn: $urn)
         }""")
     _graphql_request(query, {"urn": urn}, bearer_token)
+
+
+def delete_secret(bearer_token: str, urn: str) -> None:
+    """Delete a secret from DataHub.
+
+    Args:
+        bearer_token: Bearer token for authentication.
+        urn: URN of the secret to delete.
+    """
+    query = textwrap.dedent("""\
+        mutation deleteSecret($urn: String!) {
+            deleteSecret(urn: $urn)
+        }""")
+    _graphql_request(query, {"urn": urn}, bearer_token)

--- a/src/graphql.py
+++ b/src/graphql.py
@@ -1,0 +1,276 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""DataHub GraphQL API client functions."""
+
+import textwrap
+from typing import Any, Dict, List, Optional
+
+import requests
+
+import literals
+
+GRAPHQL_ENDPOINT = f"http://localhost:{literals.GMS_PORT}/api/graphql"
+
+
+class AuthenticationError(RuntimeError):
+    """Raised when a GraphQL request fails due to authentication issues."""
+
+
+def _graphql_request(
+    query: str,
+    variables: Optional[Dict[str, Any]],
+    token: str,
+    auth_scheme: str = "Bearer",
+) -> Dict[str, Any]:
+    """Execute a GraphQL request against the DataHub GMS endpoint.
+
+    Args:
+        query: GraphQL query or mutation string.
+        variables: Optional variables for the query.
+        token: Authentication token or credentials.
+        auth_scheme: HTTP auth scheme (e.g. "Bearer" or "Basic").
+
+    Returns:
+        The parsed JSON response body.
+
+    Raises:
+        AuthenticationError: If the request fails with a 401/403 or unauthorized GraphQL error.
+        RuntimeError: If the request fails or returns GraphQL errors.
+    """
+    headers = {
+        "Authorization": f"{auth_scheme} {token}",
+        "Content-Type": "application/json",
+    }
+    payload: Dict[str, Any] = {"query": query}
+    if variables:
+        payload["variables"] = variables
+
+    response = requests.post(GRAPHQL_ENDPOINT, json=payload, headers=headers, timeout=30)
+    if response.status_code in (401, 403):
+        raise AuthenticationError(f"Authentication failed: HTTP {response.status_code}")
+    response.raise_for_status()
+    body = response.json()
+
+    if "errors" in body and body["errors"]:
+        error_str = str(body["errors"])
+        if "unauthorized" in error_str.lower():
+            raise AuthenticationError(f"GraphQL authentication error: {body['errors']}")
+        raise RuntimeError(f"GraphQL errors: {body['errors']}")
+
+    return body
+
+
+def create_access_token(system_client_id: str, system_client_secret: str) -> str:
+    """Create a DataHub access token for the system user.
+
+    Uses Basic auth with system client credentials to bootstrap a token.
+
+    Args:
+        system_client_id: DataHub system client identifier.
+        system_client_secret: DataHub system client secret.
+
+    Returns:
+        The generated access token string.
+    """
+    query = textwrap.dedent("""\
+        mutation createAccessToken($input: CreateAccessTokenInput!) {
+            createAccessToken(input: $input) {
+                accessToken
+            }
+        }""")
+    variables = {
+        "input": {
+            "type": "PERSONAL",
+            "actorUrn": "urn:li:corpuser:__datahub_system",
+            "duration": "NO_EXPIRY",
+            "name": "juju-managed-ingestion-token",
+        }
+    }
+    basic_credentials = f"{system_client_id}:{system_client_secret}"
+    body = _graphql_request(query, variables, basic_credentials, auth_scheme="Basic")
+    return body["data"]["createAccessToken"]["accessToken"]
+
+
+def list_secrets(bearer_token: str) -> Dict[str, str]:
+    """List all DataHub secrets, returning a name-to-urn mapping.
+
+    Args:
+        bearer_token: Bearer token for authentication.
+
+    Returns:
+        Dictionary mapping secret names to their URNs.
+    """
+    query = textwrap.dedent("""\
+        query listSecrets($input: ListSecretsInput!) {
+            listSecrets(input: $input) {
+                total
+                secrets {
+                    urn
+                    name
+                }
+            }
+        }""")
+    start = 0
+    count = 100
+    secrets: Dict[str, str] = {}
+
+    while True:
+        variables = {"input": {"start": start, "count": count}}
+        body = _graphql_request(query, variables, bearer_token)
+        data = body["data"]["listSecrets"]
+        for secret in data.get("secrets", []):
+            secrets[secret["name"]] = secret["urn"]
+        if len(secrets) >= data["total"]:
+            break
+        start += count
+
+    return secrets
+
+
+def ensure_secret(
+    bearer_token: str,
+    name: str,
+    value: str,
+    existing_secrets: Dict[str, str],
+) -> None:
+    """Create or update a DataHub-managed secret.
+
+    Args:
+        bearer_token: Bearer token for authentication.
+        name: Secret name (used as reference in recipes).
+        value: Secret plaintext value.
+        existing_secrets: Current name-to-urn mapping from list_secrets.
+    """
+    urn = existing_secrets.get(name)
+    if urn:
+        query = textwrap.dedent("""\
+            mutation updateSecret($input: UpdateSecretInput!) {
+                updateSecret(input: $input)
+            }""")
+        variables = {
+            "input": {
+                "urn": urn,
+                "name": name,
+                "value": value,
+                "description": "Managed by Juju",
+            }
+        }
+    else:
+        query = textwrap.dedent("""\
+            mutation createSecret($input: CreateSecretInput!) {
+                createSecret(input: $input)
+            }""")
+        variables = {
+            "input": {
+                "name": name,
+                "value": value,
+                "description": "Managed by Juju",
+            }
+        }
+    _graphql_request(query, variables, bearer_token)
+
+
+def list_ingestion_sources(bearer_token: str) -> List[Dict[str, Any]]:
+    """Fetch all ingestion sources from DataHub.
+
+    Args:
+        bearer_token: Bearer token for authentication.
+
+    Returns:
+        List of ingestion source dictionaries.
+    """
+    query = textwrap.dedent("""\
+        query listIngestionSources($input: ListIngestionSourcesInput!) {
+            listIngestionSources(input: $input) {
+                total
+                ingestionSources {
+                    urn
+                    name
+                    type
+                    config {
+                        recipe
+                        executorId
+                        extraArgs {
+                            key
+                            value
+                        }
+                    }
+                    schedule {
+                        interval
+                        timezone
+                    }
+                }
+            }
+        }""")
+    start = 0
+    count = 100
+    all_sources: List[Dict[str, Any]] = []
+
+    while True:
+        variables = {"input": {"start": start, "count": count}}
+        body = _graphql_request(query, variables, bearer_token)
+        data = body["data"]["listIngestionSources"]
+        sources = data.get("ingestionSources", [])
+        all_sources.extend(sources)
+        if len(all_sources) >= data["total"]:
+            break
+        start += count
+
+    return all_sources
+
+
+def create_ingestion_source(
+    bearer_token: str,
+    input_data: Dict[str, Any],
+) -> str:
+    """Create a new ingestion source in DataHub.
+
+    Args:
+        bearer_token: Bearer token for authentication.
+        input_data: Pre-built UpdateIngestionSourceInput dict.
+
+    Returns:
+        URN of the newly created ingestion source.
+    """
+    query = textwrap.dedent("""\
+        mutation createIngestionSource($input: UpdateIngestionSourceInput!) {
+            createIngestionSource(input: $input)
+        }""")
+    variables = {"input": input_data}
+    body = _graphql_request(query, variables, bearer_token)
+    return body["data"]["createIngestionSource"]
+
+
+def update_ingestion_source(
+    bearer_token: str,
+    urn: str,
+    input_data: Dict[str, Any],
+) -> None:
+    """Update an existing ingestion source in DataHub.
+
+    Args:
+        bearer_token: Bearer token for authentication.
+        urn: URN of the existing ingestion source.
+        input_data: Pre-built UpdateIngestionSourceInput dict.
+    """
+    query = textwrap.dedent("""\
+        mutation updateIngestionSource($urn: String!, $input: UpdateIngestionSourceInput!) {
+            updateIngestionSource(urn: $urn, input: $input)
+        }""")
+    variables: Dict[str, Any] = {"urn": urn, "input": input_data}
+    _graphql_request(query, variables, bearer_token)
+
+
+def delete_ingestion_source(bearer_token: str, urn: str) -> None:
+    """Delete an ingestion source from DataHub.
+
+    Args:
+        bearer_token: Bearer token for authentication.
+        urn: URN of the ingestion source to delete.
+    """
+    query = textwrap.dedent("""\
+        mutation deleteIngestionSource($urn: String!) {
+            deleteIngestionSource(urn: $urn)
+        }""")
+    _graphql_request(query, {"urn": urn}, bearer_token)

--- a/src/literals.py
+++ b/src/literals.py
@@ -12,6 +12,7 @@ GMS_PORT = 8080
 INIT_PWD_SECRET_LABEL = "datahub-init-pwd"  # nosec B105
 ENCRYPTION_KEYS_SECRET_LABEL = "datahub-encryption-keys"  # nosec B105
 SYSTEM_CLIENT_SECRET_LABEL = "datahub-system-client-secret"  # nosec B105
+INGESTION_TOKEN_SECRET_LABEL = "datahub-ingestion-token"  # nosec B105
 
 # Paths for scripts baked into the rocks (see datahub_rocks/shared/scripts/).
 RUNNER_PATH = "/charm-scripts/runner.sh"

--- a/src/literals.py
+++ b/src/literals.py
@@ -14,6 +14,7 @@ ENCRYPTION_KEYS_SECRET_LABEL = "datahub-encryption-keys"  # nosec B105
 SYSTEM_CLIENT_ID = "__datahub_system"
 SYSTEM_CLIENT_SECRET_LABEL = "datahub-system-client-secret"  # nosec B105
 INGESTION_TOKEN_SECRET_LABEL = "datahub-ingestion-token"  # nosec B105
+DEFAULT_EXECUTOR_ID = "default"
 
 # Paths for scripts baked into the rocks (see datahub_rocks/shared/scripts/).
 RUNNER_PATH = "/charm-scripts/runner.sh"

--- a/src/literals.py
+++ b/src/literals.py
@@ -11,6 +11,7 @@ GMS_PORT = 8080
 
 INIT_PWD_SECRET_LABEL = "datahub-init-pwd"  # nosec B105
 ENCRYPTION_KEYS_SECRET_LABEL = "datahub-encryption-keys"  # nosec B105
+SYSTEM_CLIENT_ID = "__datahub_system"
 SYSTEM_CLIENT_SECRET_LABEL = "datahub-system-client-secret"  # nosec B105
 INGESTION_TOKEN_SECRET_LABEL = "datahub-ingestion-token"  # nosec B105
 

--- a/src/literals.py
+++ b/src/literals.py
@@ -11,6 +11,7 @@ GMS_PORT = 8080
 
 INIT_PWD_SECRET_LABEL = "datahub-init-pwd"  # nosec B105
 ENCRYPTION_KEYS_SECRET_LABEL = "datahub-encryption-keys"  # nosec B105
+SYSTEM_CLIENT_SECRET_LABEL = "datahub-system-client-secret"  # nosec B105
 
 # Paths for scripts baked into the rocks (see datahub_rocks/shared/scripts/).
 RUNNER_PATH = "/charm-scripts/runner.sh"

--- a/src/relations/kafka.py
+++ b/src/relations/kafka.py
@@ -44,7 +44,6 @@ class KafkaRelation(framework.Object):
             return
 
         if not self.charm._state.is_ready():
-            event.defer()
             return
 
         self.charm.unit.status = WaitingStatus(f"handling {event.relation.name} change")
@@ -77,7 +76,6 @@ class KafkaRelation(framework.Object):
             return
 
         if not self.charm._state.is_ready():
-            event.defer()
             return
 
         self.charm._state.kafka_connection = None

--- a/src/relations/opensearch.py
+++ b/src/relations/opensearch.py
@@ -47,7 +47,6 @@ class OpenSearchRelation(framework.Object):
             return
 
         if not self.charm._state.is_ready():
-            event.defer()
             return
 
         self.charm.unit.status = WaitingStatus(f"handling {event.relation.name} change")
@@ -65,8 +64,7 @@ class OpenSearchRelation(framework.Object):
 
         # Opensearch can fail to create the index, handle by deferring.
         if any((v is None for v in conn.values())):
-            logger.info("missing credentials from the opensearch relation, deferring")
-            event.defer()
+            logger.info("missing credentials from the opensearch relation, returning")
             return
 
         # TODO (mertalpt): Check if it is possible to attach to an uninitialized
@@ -88,7 +86,6 @@ class OpenSearchRelation(framework.Object):
             return
 
         if not self.charm._state.is_ready():
-            event.defer()
             return
 
         self.charm._state.opensearch_connection = None

--- a/src/relations/postgresql.py
+++ b/src/relations/postgresql.py
@@ -45,7 +45,6 @@ class PostgresqlRelation(framework.Object):
             return
 
         if not self.charm._state.is_ready():
-            event.defer()
             return
 
         self.charm.unit.status = WaitingStatus(f"handling {event.relation.name} change")
@@ -80,7 +79,6 @@ class PostgresqlRelation(framework.Object):
             return
 
         if not self.charm._state.is_ready():
-            event.defer()
             return
 
         self.charm._state.database_connection = None

--- a/src/relations/trino.py
+++ b/src/relations/trino.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 import random
+import re
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Set
 
@@ -25,6 +26,8 @@ GRAPHQL_ENDPOINT = f"http://localhost:{literals.GMS_PORT}/api/graphql"
 JUJU_MANAGED_KEY = "JUJU_MANAGED"
 INGESTION_NAME_PREFIX = "[juju] "
 INGESTION_NAME_SUFFIX = "-ingestion"
+GMS_TOKEN_SECRET_NAME = "JUJU_MANAGED_GMS_TOKEN"  # nosec B105
+TRINO_PASSWORD_SECRET_PREFIX = "JUJU_MANAGED_TRINO_PASSWORD_"  # nosec B105
 
 
 @dataclass
@@ -36,18 +39,14 @@ class _IngestionParams:
         username: Trino authentication username.
         password: Trino authentication password.
         access_token: DataHub access token for ingestion sink.
-        schema_pattern: JSON pattern for schema filtering.
-        table_pattern: JSON pattern for table filtering.
-        column_pattern: JSON pattern for column filtering.
+        trino_patterns: Parsed Trino filter patterns dict.
     """
 
     trino_url: str
     username: str
     password: str
     access_token: str
-    schema_pattern: str
-    table_pattern: str
-    column_pattern: str
+    trino_patterns: dict
 
 
 def _build_ingestion_name(catalog_name: str) -> str:
@@ -73,27 +72,74 @@ def _random_daily_schedule() -> str:
     return f"{minute} {hour} * * *"
 
 
-def _compile_proxy_extra_args() -> Dict[str, str]:
-    """Compile proxy-related extra args from Juju model proxy environment.
+def _compile_extra_env_vars() -> Dict[str, str]:
+    """Build the extra_env_vars dict with a Juju-managed marker and dual-case proxy vars.
+
+    Aligns with the proxy normalization in services._compile_standard_proxy_environment.
 
     Returns:
-        Dictionary of proxy environment variable key-value pairs.
+        Dictionary suitable for JSON-encoding into an extra_env_vars extraArgs value.
     """
-    args: Dict[str, str] = {}
+    env_vars: Dict[str, str] = {JUJU_MANAGED_KEY: "true"}
     proxy_map = {
-        "JUJU_CHARM_HTTP_PROXY": "HTTP_PROXY",
-        "JUJU_CHARM_HTTPS_PROXY": "HTTPS_PROXY",
-        "JUJU_CHARM_NO_PROXY": "NO_PROXY",
+        "JUJU_CHARM_HTTP_PROXY": ("HTTP_PROXY", "http_proxy"),
+        "JUJU_CHARM_HTTPS_PROXY": ("HTTPS_PROXY", "https_proxy"),
     }
-    for juju_var, target_var in proxy_map.items():
+
+    has_proxy_config = False
+    for juju_var, target_vars in proxy_map.items():
         value = os.getenv(juju_var)
-        if value:
-            args[target_var] = value
-    return args
+        if not value:
+            continue
+        has_proxy_config = True
+        for target in target_vars:
+            env_vars[target] = value
+
+    juju_no_proxy = os.getenv("JUJU_CHARM_NO_PROXY")
+    if juju_no_proxy:
+        has_proxy_config = True
+
+    if has_proxy_config:
+        no_proxy_values: List[str] = []
+        if juju_no_proxy:
+            no_proxy_values.extend(h.strip() for h in juju_no_proxy.split(",") if h.strip())
+        if no_proxy_values:
+            unique = list(dict.fromkeys(no_proxy_values))
+            no_proxy = ",".join(unique)
+            env_vars["NO_PROXY"] = no_proxy
+            env_vars["no_proxy"] = no_proxy
+
+    return env_vars
+
+
+def _build_managed_extra_args() -> List[Dict[str, str]]:
+    """Build the extraArgs list with a single extra_env_vars entry.
+
+    Returns:
+        A list with one StringMapEntry containing JSON-encoded env vars.
+    """
+    env_vars = _compile_extra_env_vars()
+    return [{"key": "extra_env_vars", "value": json.dumps(env_vars)}]
+
+
+def _normalize_secret_name(catalog_name: str) -> str:
+    """Build a DataHub secret name for a catalog's Trino password.
+
+    Args:
+        catalog_name: Trino catalog name.
+
+    Returns:
+        Deterministic secret name safe for DataHub.
+    """
+    normalized = re.sub(r"[^a-zA-Z0-9]", "_", catalog_name).upper()
+    return f"{TRINO_PASSWORD_SECRET_PREFIX}{normalized}"
 
 
 def _build_recipe(catalog_name: str, params: "_IngestionParams") -> str:
     """Build a DataHub ingestion recipe YAML string for a Trino catalog.
+
+    Credentials are referenced via DataHub-managed secret placeholders
+    so that raw values are never stored in the recipe.
 
     Args:
         catalog_name: Trino catalog name (used as the database field).
@@ -102,6 +148,8 @@ def _build_recipe(catalog_name: str, params: "_IngestionParams") -> str:
     Returns:
         JSON-encoded recipe string.
     """
+    default_pattern = {"allow": [".*"], "deny": []}
+    patterns = params.trino_patterns
     recipe = {
         "source": {
             "type": "trino",
@@ -109,10 +157,10 @@ def _build_recipe(catalog_name: str, params: "_IngestionParams") -> str:
                 "host_port": params.trino_url,
                 "database": catalog_name,
                 "username": params.username,
-                "password": params.password,
-                "schema_pattern": json.loads(params.schema_pattern),
-                "table_pattern": json.loads(params.table_pattern),
-                "column_pattern": json.loads(params.column_pattern),
+                "password": f"${{{_normalize_secret_name(catalog_name)}}}",
+                "schema_pattern": patterns.get("schema-pattern", default_pattern),
+                "table_pattern": patterns.get("table-pattern", default_pattern),
+                "view_pattern": patterns.get("view-pattern", default_pattern),
                 "env": "PROD",
                 "stateful_ingestion": {"enabled": True},
             },
@@ -121,11 +169,15 @@ def _build_recipe(catalog_name: str, params: "_IngestionParams") -> str:
             "type": "datahub-rest",
             "config": {
                 "server": f"http://localhost:{literals.GMS_PORT}",
-                "token": params.access_token,
+                "token": f"${{{GMS_TOKEN_SECRET_NAME}}}",
             },
         },
     }
     return json.dumps(recipe)
+
+
+class _AuthenticationError(RuntimeError):
+    """Raised when a GraphQL request fails due to authentication issues."""
 
 
 def _graphql_request(
@@ -146,6 +198,7 @@ def _graphql_request(
         The parsed JSON response body.
 
     Raises:
+        _AuthenticationError: If the request fails with a 401/403 or unauthorized GraphQL error.
         RuntimeError: If the request fails or returns GraphQL errors.
     """
     headers = {
@@ -157,10 +210,15 @@ def _graphql_request(
         payload["variables"] = variables
 
     response = requests.post(GRAPHQL_ENDPOINT, json=payload, headers=headers, timeout=30)
+    if response.status_code in (401, 403):
+        raise _AuthenticationError(f"Authentication failed: HTTP {response.status_code}")
     response.raise_for_status()
     body = response.json()
 
     if "errors" in body and body["errors"]:
+        error_str = str(body["errors"])
+        if "unauthorized" in error_str.lower():
+            raise _AuthenticationError(f"GraphQL authentication error: {body['errors']}")
         raise RuntimeError(f"GraphQL errors: {body['errors']}")
 
     return body
@@ -196,6 +254,88 @@ def _create_access_token(system_client_id: str, system_client_secret: str) -> st
     basic_credentials = f"{system_client_id}:{system_client_secret}"
     body = _graphql_request(query, variables, basic_credentials, auth_scheme="Basic")
     return body["data"]["createAccessToken"]["accessToken"]
+
+
+def _list_secrets(bearer_token: str) -> Dict[str, str]:
+    """List all DataHub secrets, returning a name-to-urn mapping.
+
+    Args:
+        bearer_token: Bearer token for authentication.
+
+    Returns:
+        Dictionary mapping secret names to their URNs.
+    """
+    query = """
+    query listSecrets($input: ListSecretsInput!) {
+        listSecrets(input: $input) {
+            total
+            secrets {
+                urn
+                name
+            }
+        }
+    }
+    """
+    start = 0
+    count = 100
+    secrets: Dict[str, str] = {}
+
+    while True:
+        variables = {"input": {"start": start, "count": count}}
+        body = _graphql_request(query, variables, bearer_token)
+        data = body["data"]["listSecrets"]
+        for secret in data.get("secrets", []):
+            secrets[secret["name"]] = secret["urn"]
+        if len(secrets) >= data["total"]:
+            break
+        start += count
+
+    return secrets
+
+
+def _ensure_secret(
+    bearer_token: str,
+    name: str,
+    value: str,
+    existing_secrets: Dict[str, str],
+) -> None:
+    """Create or update a DataHub-managed secret.
+
+    Args:
+        bearer_token: Bearer token for authentication.
+        name: Secret name (used as reference in recipes).
+        value: Secret plaintext value.
+        existing_secrets: Current name-to-urn mapping from _list_secrets.
+    """
+    urn = existing_secrets.get(name)
+    if urn:
+        query = """
+        mutation updateSecret($input: UpdateSecretInput!) {
+            updateSecret(input: $input)
+        }
+        """
+        variables = {
+            "input": {
+                "urn": urn,
+                "name": name,
+                "value": value,
+                "description": "Managed by Juju",
+            }
+        }
+    else:
+        query = """
+        mutation createSecret($input: CreateSecretInput!) {
+            createSecret(input: $input)
+        }
+        """
+        variables = {
+            "input": {
+                "name": name,
+                "value": value,
+                "description": "Managed by Juju",
+            }
+        }
+    _graphql_request(query, variables, bearer_token)
 
 
 def _list_ingestion_sources(bearer_token: str) -> List[Dict[str, Any]]:
@@ -251,17 +391,31 @@ def _list_ingestion_sources(bearer_token: str) -> List[Dict[str, Any]]:
 def _filter_juju_managed(sources: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """Filter ingestion sources to those marked as Juju-managed.
 
+    Supports both the current extra_env_vars JSON format and the legacy
+    top-level JUJU_MANAGED key for migration compatibility.
+
     Args:
         sources: List of ingestion source dicts from the GraphQL response.
 
     Returns:
-        Subset of sources that have JUJU_MANAGED=True in extraArgs.
+        Subset of sources that are Juju-managed.
     """
     managed = []
     for source in sources:
         extra_args = source.get("config", {}).get("extraArgs") or []
         for arg in extra_args:
-            if arg.get("key") == JUJU_MANAGED_KEY and arg.get("value") == "True":
+            key = arg.get("key")
+            # Current format: JUJU_MANAGED inside extra_env_vars JSON
+            if key == "extra_env_vars":
+                try:
+                    env_vars = json.loads(arg.get("value", "{}"))
+                    if env_vars.get(JUJU_MANAGED_KEY) == "true":
+                        managed.append(source)
+                        break
+                except (json.JSONDecodeError, TypeError):
+                    pass
+            # Legacy format: top-level JUJU_MANAGED key
+            if key == JUJU_MANAGED_KEY and arg.get("value") == "True":
                 managed.append(source)
                 break
     return managed
@@ -288,10 +442,7 @@ def _create_ingestion_source(
     }
     """
     recipe = _build_recipe(catalog_name, params)
-    proxy_args = _compile_proxy_extra_args()
-    extra_args_list = [{"key": JUJU_MANAGED_KEY, "value": "True"}]
-    for k, v in proxy_args.items():
-        extra_args_list.append({"key": k, "value": v})
+    extra_args_list = _build_managed_extra_args()
 
     variables = {
         "input": {
@@ -336,14 +487,11 @@ def _update_ingestion_source(
     """
     recipe = _build_recipe(_extract_catalog_from_name(existing_source["name"]), params)
 
-    # Preserve existing extraArgs but update proxy and JUJU_MANAGED keys.
+    # Preserve non-managed extraArgs; replace the managed extra_env_vars block atomically.
     existing_extra = existing_source.get("config", {}).get("extraArgs") or []
-    proxy_args = _compile_proxy_extra_args()
-    managed_keys = {JUJU_MANAGED_KEY, "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"}
+    managed_keys = {JUJU_MANAGED_KEY, "extra_env_vars", "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"}
     preserved = [a for a in existing_extra if a.get("key") not in managed_keys]
-    preserved.append({"key": JUJU_MANAGED_KEY, "value": "True"})
-    for k, v in proxy_args.items():
-        preserved.append({"key": k, "value": v})
+    preserved.extend(_build_managed_extra_args())
 
     existing_schedule = existing_source.get("schedule")
     schedule_input = None
@@ -429,7 +577,7 @@ class TrinoRelation(framework.Object):
             self._on_relation_broken,
         )
 
-        self._access_token: Optional[str] = None
+        self._access_token: Optional[str] = None  # type: ignore[annotation-unchecked]
 
     @property
     def access_token(self) -> str:
@@ -492,37 +640,67 @@ class TrinoRelation(framework.Object):
         username, password = credentials
         trino_url = trino_info["trino_url"]
         catalogs = trino_info["trino_catalogs"]
-
         desired_catalogs = {catalog.name for catalog in catalogs}
 
+        config = self.charm.config
         try:
-            access_token = self.access_token
-
-            all_sources = _list_ingestion_sources(access_token)
-            managed = _filter_juju_managed(all_sources)
-        except Exception as e:
-            logger.error("Failed to fetch ingestion sources from DataHub: %s", str(e))
+            trino_patterns = json.loads(config.trino_patterns)
+        except (json.JSONDecodeError, TypeError) as e:
+            logger.error("Invalid trino-patterns config: %s", str(e))
             return
+
+        result = self._prepare_ingestion_state(catalogs, password)
+        if result is None:
+            return
+        access_token, managed = result
 
         existing_by_catalog: Dict[str, Dict[str, Any]] = {}
         for source in managed:
             catalog_name = _extract_catalog_from_name(source["name"])
             existing_by_catalog[catalog_name] = source
 
-        config = self.charm.config
         params = _IngestionParams(
             trino_url=trino_url,
             username=username,
             password=password,
             access_token=access_token,
-            schema_pattern=config.schema_pattern,
-            table_pattern=config.table_pattern,
-            column_pattern=config.column_pattern,
+            trino_patterns=trino_patterns,
         )
 
         self._create_missing_ingestions(desired_catalogs, existing_by_catalog, access_token, params)
         self._update_existing_ingestions(desired_catalogs, existing_by_catalog, access_token, params)
         self._delete_obsolete_ingestions(desired_catalogs, existing_by_catalog, access_token)
+
+    def _prepare_ingestion_state(self, catalogs, password: str) -> Optional[tuple]:
+        """Ensure secrets exist and fetch managed ingestion sources, retrying on auth failure.
+
+        Args:
+            catalogs: List of Trino catalog objects with a .name attribute.
+            password: Current Trino password for per-catalog secrets.
+
+        Returns:
+            Tuple of (access_token, managed_sources) or None on failure.
+        """
+        for attempt in range(2):
+            try:
+                access_token = self.access_token
+                secrets_map = _list_secrets(access_token)
+                _ensure_secret(access_token, GMS_TOKEN_SECRET_NAME, access_token, secrets_map)
+                for catalog in catalogs:
+                    _ensure_secret(access_token, _normalize_secret_name(catalog.name), password, secrets_map)
+                all_sources = _list_ingestion_sources(access_token)
+                managed = _filter_juju_managed(all_sources)
+                return access_token, managed
+            except _AuthenticationError:
+                if attempt == 0:
+                    logger.info("Authentication failed, refreshing token and retrying")
+                    self._access_token = None
+                    continue
+                logger.error("Authentication failed after token refresh")
+            except Exception as e:
+                logger.error("Failed to prepare ingestion reconciliation: %s", str(e))
+                break
+        return None
 
     def _create_missing_ingestions(
         self,

--- a/src/relations/trino.py
+++ b/src/relations/trino.py
@@ -11,18 +11,17 @@ import re
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Set
 
-import requests
 from charms.trino_k8s.v0.trino_catalog import (
     TrinoCatalogRequirer,  # pylint: disable=E0611
 )
 from ops import WaitingStatus, framework
 
+import graphql
 import literals
 from log import log_event_handler
 
 logger = logging.getLogger(__name__)
 
-GRAPHQL_ENDPOINT = f"http://localhost:{literals.GMS_PORT}/api/graphql"
 JUJU_MANAGED_KEY = "JUJU_MANAGED"
 INGESTION_NAME_PREFIX = "[juju] "
 INGESTION_NAME_SUFFIX = "-ingestion"
@@ -176,218 +175,6 @@ def _build_recipe(catalog_name: str, params: "_IngestionParams") -> str:
     return json.dumps(recipe)
 
 
-class _AuthenticationError(RuntimeError):
-    """Raised when a GraphQL request fails due to authentication issues."""
-
-
-def _graphql_request(
-    query: str,
-    variables: Optional[Dict[str, Any]],
-    token: str,
-    auth_scheme: str = "Bearer",
-) -> Dict[str, Any]:
-    """Execute a GraphQL request against the DataHub GMS endpoint.
-
-    Args:
-        query: GraphQL query or mutation string.
-        variables: Optional variables for the query.
-        token: Authentication token or credentials.
-        auth_scheme: HTTP auth scheme (e.g. "Bearer" or "Basic").
-
-    Returns:
-        The parsed JSON response body.
-
-    Raises:
-        _AuthenticationError: If the request fails with a 401/403 or unauthorized GraphQL error.
-        RuntimeError: If the request fails or returns GraphQL errors.
-    """
-    headers = {
-        "Authorization": f"{auth_scheme} {token}",
-        "Content-Type": "application/json",
-    }
-    payload: Dict[str, Any] = {"query": query}
-    if variables:
-        payload["variables"] = variables
-
-    response = requests.post(GRAPHQL_ENDPOINT, json=payload, headers=headers, timeout=30)
-    if response.status_code in (401, 403):
-        raise _AuthenticationError(f"Authentication failed: HTTP {response.status_code}")
-    response.raise_for_status()
-    body = response.json()
-
-    if "errors" in body and body["errors"]:
-        error_str = str(body["errors"])
-        if "unauthorized" in error_str.lower():
-            raise _AuthenticationError(f"GraphQL authentication error: {body['errors']}")
-        raise RuntimeError(f"GraphQL errors: {body['errors']}")
-
-    return body
-
-
-def _create_access_token(system_client_id: str, system_client_secret: str) -> str:
-    """Create a DataHub access token for the system user.
-
-    Uses Basic auth with system client credentials to bootstrap a token.
-
-    Args:
-        system_client_id: DataHub system client identifier.
-        system_client_secret: DataHub system client secret.
-
-    Returns:
-        The generated access token string.
-    """
-    query = """
-    mutation createAccessToken($input: CreateAccessTokenInput!) {
-        createAccessToken(input: $input) {
-            accessToken
-        }
-    }
-    """
-    variables = {
-        "input": {
-            "type": "PERSONAL",
-            "actorUrn": "urn:li:corpuser:__datahub_system",
-            "duration": "NO_EXPIRY",
-            "name": "juju-managed-ingestion-token",
-        }
-    }
-    basic_credentials = f"{system_client_id}:{system_client_secret}"
-    body = _graphql_request(query, variables, basic_credentials, auth_scheme="Basic")
-    return body["data"]["createAccessToken"]["accessToken"]
-
-
-def _list_secrets(bearer_token: str) -> Dict[str, str]:
-    """List all DataHub secrets, returning a name-to-urn mapping.
-
-    Args:
-        bearer_token: Bearer token for authentication.
-
-    Returns:
-        Dictionary mapping secret names to their URNs.
-    """
-    query = """
-    query listSecrets($input: ListSecretsInput!) {
-        listSecrets(input: $input) {
-            total
-            secrets {
-                urn
-                name
-            }
-        }
-    }
-    """
-    start = 0
-    count = 100
-    secrets: Dict[str, str] = {}
-
-    while True:
-        variables = {"input": {"start": start, "count": count}}
-        body = _graphql_request(query, variables, bearer_token)
-        data = body["data"]["listSecrets"]
-        for secret in data.get("secrets", []):
-            secrets[secret["name"]] = secret["urn"]
-        if len(secrets) >= data["total"]:
-            break
-        start += count
-
-    return secrets
-
-
-def _ensure_secret(
-    bearer_token: str,
-    name: str,
-    value: str,
-    existing_secrets: Dict[str, str],
-) -> None:
-    """Create or update a DataHub-managed secret.
-
-    Args:
-        bearer_token: Bearer token for authentication.
-        name: Secret name (used as reference in recipes).
-        value: Secret plaintext value.
-        existing_secrets: Current name-to-urn mapping from _list_secrets.
-    """
-    urn = existing_secrets.get(name)
-    if urn:
-        query = """
-        mutation updateSecret($input: UpdateSecretInput!) {
-            updateSecret(input: $input)
-        }
-        """
-        variables = {
-            "input": {
-                "urn": urn,
-                "name": name,
-                "value": value,
-                "description": "Managed by Juju",
-            }
-        }
-    else:
-        query = """
-        mutation createSecret($input: CreateSecretInput!) {
-            createSecret(input: $input)
-        }
-        """
-        variables = {
-            "input": {
-                "name": name,
-                "value": value,
-                "description": "Managed by Juju",
-            }
-        }
-    _graphql_request(query, variables, bearer_token)
-
-
-def _list_ingestion_sources(bearer_token: str) -> List[Dict[str, Any]]:
-    """Fetch all ingestion sources from DataHub.
-
-    Args:
-        bearer_token: Bearer token for authentication.
-
-    Returns:
-        List of ingestion source dictionaries.
-    """
-    query = """
-    query listIngestionSources($input: ListIngestionSourcesInput!) {
-        listIngestionSources(input: $input) {
-            total
-            ingestionSources {
-                urn
-                name
-                type
-                config {
-                    recipe
-                    executorId
-                    extraArgs {
-                        key
-                        value
-                    }
-                }
-                schedule {
-                    interval
-                    timezone
-                }
-            }
-        }
-    }
-    """
-    start = 0
-    count = 100
-    all_sources: List[Dict[str, Any]] = []
-
-    while True:
-        variables = {"input": {"start": start, "count": count}}
-        body = _graphql_request(query, variables, bearer_token)
-        data = body["data"]["listIngestionSources"]
-        sources = data.get("ingestionSources", [])
-        all_sources.extend(sources)
-        if len(all_sources) >= data["total"]:
-            break
-        start += count
-
-    return all_sources
-
-
 def _filter_juju_managed(sources: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """Filter ingestion sources to those marked as Juju-managed.
 
@@ -436,32 +223,24 @@ def _create_ingestion_source(
     Returns:
         URN of the newly created ingestion source.
     """
-    query = """
-    mutation createIngestionSource($input: UpdateIngestionSourceInput!) {
-        createIngestionSource(input: $input)
-    }
-    """
     recipe = _build_recipe(catalog_name, params)
     extra_args_list = _build_managed_extra_args()
 
-    variables = {
-        "input": {
-            "name": _build_ingestion_name(catalog_name),
-            "type": "trino",
-            "description": f"Juju managed Trino ingestion for {catalog_name}",
-            "schedule": {
-                "interval": _random_daily_schedule(),
-                "timezone": "UTC",
-            },
-            "config": {
-                "recipe": recipe,
-                "executorId": "default",
-                "extraArgs": extra_args_list,
-            },
-        }
+    input_data = {
+        "name": _build_ingestion_name(catalog_name),
+        "type": "trino",
+        "description": f"Juju managed Trino ingestion for {catalog_name}",
+        "schedule": {
+            "interval": _random_daily_schedule(),
+            "timezone": "UTC",
+        },
+        "config": {
+            "recipe": recipe,
+            "executorId": "default",
+            "extraArgs": extra_args_list,
+        },
     }
-    body = _graphql_request(query, variables, bearer_token)
-    return body["data"]["createIngestionSource"]
+    return graphql.create_ingestion_source(bearer_token, input_data)
 
 
 def _update_ingestion_source(
@@ -479,11 +258,6 @@ def _update_ingestion_source(
         urn: URN of the existing ingestion source.
         existing_source: Current source dict from listIngestionSources.
         params: Common ingestion parameters.
-    """
-    query = """
-    mutation updateIngestionSource($urn: String!, $input: UpdateIngestionSourceInput!) {
-        updateIngestionSource(urn: $urn, input: $input)
-    }
     """
     recipe = _build_recipe(_extract_catalog_from_name(existing_source["name"]), params)
 
@@ -513,27 +287,7 @@ def _update_ingestion_source(
     if schedule_input:
         input_data["schedule"] = schedule_input
 
-    variables: Dict[str, Any] = {
-        "urn": urn,
-        "input": input_data,
-    }
-
-    _graphql_request(query, variables, bearer_token)
-
-
-def _delete_ingestion_source(bearer_token: str, urn: str) -> None:
-    """Delete an ingestion source from DataHub.
-
-    Args:
-        bearer_token: Bearer token for authentication.
-        urn: URN of the ingestion source to delete.
-    """
-    query = """
-    mutation deleteIngestionSource($urn: String!) {
-        deleteIngestionSource(urn: $urn)
-    }
-    """
-    _graphql_request(query, {"urn": urn}, bearer_token)
+    graphql.update_ingestion_source(bearer_token, urn, input_data)
 
 
 def _extract_catalog_from_name(name: str) -> str:
@@ -632,7 +386,7 @@ class TrinoRelation(framework.Object):
             self._access_token = stored
             return self._access_token
 
-        token = _create_access_token(self.charm.system_client_id, self.charm.system_client_secret)
+        token = graphql.create_access_token(self.charm.system_client_id, self.charm.system_client_secret)
         self._access_token = token
         self._store_access_token(token)
         return self._access_token
@@ -731,18 +485,18 @@ class TrinoRelation(framework.Object):
         for attempt in range(2):
             try:
                 access_token = self.access_token
-                secrets_map = _list_secrets(access_token)
-                _ensure_secret(access_token, GMS_TOKEN_SECRET_NAME, access_token, secrets_map)
+                secrets_map = graphql.list_secrets(access_token)
+                graphql.ensure_secret(access_token, GMS_TOKEN_SECRET_NAME, access_token, secrets_map)
                 for catalog in catalogs:
-                    _ensure_secret(access_token, _normalize_secret_name(catalog.name), password, secrets_map)
-                all_sources = _list_ingestion_sources(access_token)
+                    graphql.ensure_secret(access_token, _normalize_secret_name(catalog.name), password, secrets_map)
+                all_sources = graphql.list_ingestion_sources(access_token)
                 managed = _filter_juju_managed(all_sources)
                 return access_token, managed
-            except _AuthenticationError:
+            except graphql.AuthenticationError:
                 if attempt == 0:
                     logger.info("Authentication failed, refreshing token and retrying")
                     self._access_token = None
-                    token = _create_access_token(self.charm.system_client_id, self.charm.system_client_secret)
+                    token = graphql.create_access_token(self.charm.system_client_id, self.charm.system_client_secret)
                     self._access_token = token
                     self._store_access_token(token)
                     continue
@@ -802,7 +556,7 @@ class TrinoRelation(framework.Object):
         for catalog_name in set(existing.keys()) - desired:
             source = existing[catalog_name]
             try:
-                _delete_ingestion_source(bearer, source["urn"])
+                graphql.delete_ingestion_source(bearer, source["urn"])
                 logger.info("Deleted obsolete ingestion source for catalog '%s'", catalog_name)
             except Exception as e:
                 logger.error("Failed to delete ingestion for catalog '%s': %s", catalog_name, str(e))
@@ -811,7 +565,7 @@ class TrinoRelation(framework.Object):
         """Delete all Juju-managed Trino ingestion sources (relation-broken cleanup)."""
         try:
             access_token = self.access_token
-            all_sources = _list_ingestion_sources(access_token)
+            all_sources = graphql.list_ingestion_sources(access_token)
             managed = _filter_juju_managed(all_sources)
         except Exception as e:
             logger.error("Failed to fetch ingestion sources during cleanup: %s", str(e))
@@ -819,7 +573,7 @@ class TrinoRelation(framework.Object):
 
         for source in managed:
             try:
-                _delete_ingestion_source(access_token, source["urn"])
+                graphql.delete_ingestion_source(access_token, source["urn"])
                 logger.info("Cleaned up ingestion source '%s'", source["name"])
             except Exception as e:
                 logger.error("Failed to clean up ingestion '%s': %s", source["name"], str(e))

--- a/src/relations/trino.py
+++ b/src/relations/trino.py
@@ -1,0 +1,592 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Define DataHub-Trino relation and ingestion reconciliation."""
+
+import json
+import logging
+import os
+import random
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Set
+
+import requests
+from charms.trino_k8s.v0.trino_catalog import (
+    TrinoCatalogRequirer,  # pylint: disable=E0611
+)
+from ops import WaitingStatus, framework
+
+import literals
+from log import log_event_handler
+
+logger = logging.getLogger(__name__)
+
+GRAPHQL_ENDPOINT = f"http://localhost:{literals.GMS_PORT}/api/graphql"
+JUJU_MANAGED_KEY = "JUJU_MANAGED"
+INGESTION_NAME_PREFIX = "[juju] "
+INGESTION_NAME_SUFFIX = "-ingestion"
+
+
+@dataclass
+class _IngestionParams:
+    """Common parameters for Trino ingestion source operations.
+
+    Attributes:
+        trino_url: URL of the Trino server.
+        username: Trino authentication username.
+        password: Trino authentication password.
+        access_token: DataHub access token for ingestion sink.
+        schema_pattern: JSON pattern for schema filtering.
+        table_pattern: JSON pattern for table filtering.
+        column_pattern: JSON pattern for column filtering.
+    """
+
+    trino_url: str
+    username: str
+    password: str
+    access_token: str
+    schema_pattern: str
+    table_pattern: str
+    column_pattern: str
+
+
+def _build_ingestion_name(catalog_name: str) -> str:
+    """Build the canonical ingestion source name for a catalog.
+
+    Args:
+        catalog_name: Name of the Trino catalog.
+
+    Returns:
+        Formatted ingestion source name.
+    """
+    return f"{INGESTION_NAME_PREFIX}{catalog_name}{INGESTION_NAME_SUFFIX}"
+
+
+def _random_daily_schedule() -> str:
+    """Generate a random daily cron schedule between 22:00 and 06:00 UTC.
+
+    Returns:
+        A cron expression string for a daily run.
+    """
+    hour = random.choice([22, 23, 0, 1, 2, 3, 4, 5])  # nosec B311
+    minute = random.randint(0, 59)  # nosec B311
+    return f"{minute} {hour} * * *"
+
+
+def _compile_proxy_extra_args() -> Dict[str, str]:
+    """Compile proxy-related extra args from Juju model proxy environment.
+
+    Returns:
+        Dictionary of proxy environment variable key-value pairs.
+    """
+    args: Dict[str, str] = {}
+    proxy_map = {
+        "JUJU_CHARM_HTTP_PROXY": "HTTP_PROXY",
+        "JUJU_CHARM_HTTPS_PROXY": "HTTPS_PROXY",
+        "JUJU_CHARM_NO_PROXY": "NO_PROXY",
+    }
+    for juju_var, target_var in proxy_map.items():
+        value = os.getenv(juju_var)
+        if value:
+            args[target_var] = value
+    return args
+
+
+def _build_recipe(catalog_name: str, params: "_IngestionParams") -> str:
+    """Build a DataHub ingestion recipe YAML string for a Trino catalog.
+
+    Args:
+        catalog_name: Trino catalog name (used as the database field).
+        params: Common ingestion parameters.
+
+    Returns:
+        JSON-encoded recipe string.
+    """
+    recipe = {
+        "source": {
+            "type": "trino",
+            "config": {
+                "host_port": params.trino_url,
+                "database": catalog_name,
+                "username": params.username,
+                "password": params.password,
+                "schema_pattern": json.loads(params.schema_pattern),
+                "table_pattern": json.loads(params.table_pattern),
+                "column_pattern": json.loads(params.column_pattern),
+                "env": "PROD",
+                "stateful_ingestion": {"enabled": True},
+            },
+        },
+        "sink": {
+            "type": "datahub-rest",
+            "config": {
+                "server": f"http://localhost:{literals.GMS_PORT}",
+                "token": params.access_token,
+            },
+        },
+    }
+    return json.dumps(recipe)
+
+
+def _graphql_request(
+    query: str,
+    variables: Optional[Dict[str, Any]],
+    bearer_token: str,
+) -> Dict[str, Any]:
+    """Execute a GraphQL request against the DataHub GMS endpoint.
+
+    Args:
+        query: GraphQL query or mutation string.
+        variables: Optional variables for the query.
+        bearer_token: Bearer token for authentication.
+
+    Returns:
+        The parsed JSON response body.
+
+    Raises:
+        RuntimeError: If the request fails or returns GraphQL errors.
+    """
+    headers = {
+        "Authorization": f"Bearer {bearer_token}",
+        "Content-Type": "application/json",
+    }
+    payload: Dict[str, Any] = {"query": query}
+    if variables:
+        payload["variables"] = variables
+
+    response = requests.post(GRAPHQL_ENDPOINT, json=payload, headers=headers, timeout=30)
+    response.raise_for_status()
+    body = response.json()
+
+    if "errors" in body and body["errors"]:
+        raise RuntimeError(f"GraphQL errors: {body['errors']}")
+
+    return body
+
+
+def _create_access_token(bearer_token: str) -> str:
+    """Create a DataHub access token for the system user.
+
+    Args:
+        bearer_token: System client secret used as bearer for this request.
+
+    Returns:
+        The generated access token string.
+    """
+    query = """
+    mutation createAccessToken($input: CreateAccessTokenInput!) {
+        createAccessToken(input: $input) {
+            accessToken
+        }
+    }
+    """
+    variables = {
+        "input": {
+            "type": "PERSONAL",
+            "actorUrn": "urn:li:corpuser:__datahub_system",
+            "duration": "NO_EXPIRY",
+            "name": "juju-managed-ingestion-token",
+        }
+    }
+    body = _graphql_request(query, variables, bearer_token)
+    return body["data"]["createAccessToken"]["accessToken"]
+
+
+def _list_ingestion_sources(bearer_token: str) -> List[Dict[str, Any]]:
+    """Fetch all ingestion sources from DataHub.
+
+    Args:
+        bearer_token: Bearer token for authentication.
+
+    Returns:
+        List of ingestion source dictionaries.
+    """
+    query = """
+    query listIngestionSources($input: ListIngestionSourcesInput!) {
+        listIngestionSources(input: $input) {
+            total
+            ingestionSources {
+                urn
+                name
+                type
+                config {
+                    recipe
+                    executorId
+                    extraArgs {
+                        key
+                        value
+                    }
+                }
+                schedule {
+                    interval
+                    timezone
+                }
+            }
+        }
+    }
+    """
+    start = 0
+    count = 100
+    all_sources: List[Dict[str, Any]] = []
+
+    while True:
+        variables = {"input": {"start": start, "count": count}}
+        body = _graphql_request(query, variables, bearer_token)
+        data = body["data"]["listIngestionSources"]
+        sources = data.get("ingestionSources", [])
+        all_sources.extend(sources)
+        if len(all_sources) >= data["total"]:
+            break
+        start += count
+
+    return all_sources
+
+
+def _filter_juju_managed(sources: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Filter ingestion sources to those marked as Juju-managed.
+
+    Args:
+        sources: List of ingestion source dicts from the GraphQL response.
+
+    Returns:
+        Subset of sources that have JUJU_MANAGED=True in extraArgs.
+    """
+    managed = []
+    for source in sources:
+        extra_args = source.get("config", {}).get("extraArgs") or []
+        for arg in extra_args:
+            if arg.get("key") == JUJU_MANAGED_KEY and arg.get("value") == "True":
+                managed.append(source)
+                break
+    return managed
+
+
+def _create_ingestion_source(
+    bearer_token: str,
+    catalog_name: str,
+    params: "_IngestionParams",
+) -> str:
+    """Create a new ingestion source in DataHub.
+
+    Args:
+        bearer_token: Bearer token for authentication.
+        catalog_name: Trino catalog name.
+        params: Common ingestion parameters.
+
+    Returns:
+        URN of the newly created ingestion source.
+    """
+    query = """
+    mutation createIngestionSource($input: UpdateIngestionSourceInput!) {
+        createIngestionSource(input: $input)
+    }
+    """
+    recipe = _build_recipe(catalog_name, params)
+    proxy_args = _compile_proxy_extra_args()
+    extra_args_list = [{"key": JUJU_MANAGED_KEY, "value": "True"}]
+    for k, v in proxy_args.items():
+        extra_args_list.append({"key": k, "value": v})
+
+    variables = {
+        "input": {
+            "name": _build_ingestion_name(catalog_name),
+            "type": "trino",
+            "description": f"Juju managed Trino ingestion for {catalog_name}",
+            "schedule": {
+                "interval": _random_daily_schedule(),
+                "timezone": "UTC",
+            },
+            "config": {
+                "recipe": recipe,
+                "executorId": "default",
+                "extraArgs": extra_args_list,
+            },
+        }
+    }
+    body = _graphql_request(query, variables, bearer_token)
+    return body["data"]["createIngestionSource"]
+
+
+def _update_ingestion_source(
+    bearer_token: str,
+    urn: str,
+    existing_source: Dict[str, Any],
+    params: "_IngestionParams",
+) -> None:
+    """Update credentials and proxy vars of an existing ingestion source.
+
+    Preserves name, type, description, schedule, and other settings.
+
+    Args:
+        bearer_token: Bearer token for authentication.
+        urn: URN of the existing ingestion source.
+        existing_source: Current source dict from listIngestionSources.
+        params: Common ingestion parameters.
+    """
+    query = """
+    mutation updateIngestionSource($urn: String!, $input: UpdateIngestionSourceInput!) {
+        updateIngestionSource(urn: $urn, input: $input)
+    }
+    """
+    recipe = _build_recipe(_extract_catalog_from_name(existing_source["name"]), params)
+
+    # Preserve existing extraArgs but update proxy and JUJU_MANAGED keys.
+    existing_extra = existing_source.get("config", {}).get("extraArgs") or []
+    proxy_args = _compile_proxy_extra_args()
+    managed_keys = {JUJU_MANAGED_KEY, "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"}
+    preserved = [a for a in existing_extra if a.get("key") not in managed_keys]
+    preserved.append({"key": JUJU_MANAGED_KEY, "value": "True"})
+    for k, v in proxy_args.items():
+        preserved.append({"key": k, "value": v})
+
+    existing_schedule = existing_source.get("schedule")
+    schedule_input = None
+    if existing_schedule:
+        schedule_input = {
+            "interval": existing_schedule["interval"],
+            "timezone": existing_schedule.get("timezone", "UTC"),
+        }
+
+    input_data: Dict[str, Any] = {
+        "name": existing_source["name"],
+        "type": existing_source.get("type", "trino"),
+        "config": {
+            "recipe": recipe,
+            "executorId": existing_source.get("config", {}).get("executorId", "default"),
+            "extraArgs": preserved,
+        },
+    }
+    if schedule_input:
+        input_data["schedule"] = schedule_input
+
+    variables: Dict[str, Any] = {
+        "urn": urn,
+        "input": input_data,
+    }
+
+    _graphql_request(query, variables, bearer_token)
+
+
+def _delete_ingestion_source(bearer_token: str, urn: str) -> None:
+    """Delete an ingestion source from DataHub.
+
+    Args:
+        bearer_token: Bearer token for authentication.
+        urn: URN of the ingestion source to delete.
+    """
+    query = """
+    mutation deleteIngestionSource($urn: String!) {
+        deleteIngestionSource(urn: $urn)
+    }
+    """
+    _graphql_request(query, {"urn": urn}, bearer_token)
+
+
+def _extract_catalog_from_name(name: str) -> str:
+    """Extract catalog name from the standard ingestion source name.
+
+    Args:
+        name: Ingestion source name of the form '[juju] <catalog>-ingestion'.
+
+    Returns:
+        The catalog name portion.
+    """
+    stripped = name.removeprefix(INGESTION_NAME_PREFIX).removesuffix(INGESTION_NAME_SUFFIX)
+    return stripped
+
+
+class TrinoRelation(framework.Object):
+    """Client for datahub:trino-catalog relations.
+
+    Attributes:
+        trino_catalog: TrinoCatalogRequirer instance for relation data access.
+        access_token: DataHub access token for ingestion source management.
+    """
+
+    def __init__(self, charm):
+        """Construct.
+
+        Args:
+            charm: The charm to attach the hooks to.
+        """
+        super().__init__(charm, "trino-catalog")
+        self.charm = charm
+
+        self.trino_catalog = TrinoCatalogRequirer(charm, relation_name="trino-catalog")
+
+        charm.framework.observe(
+            charm.on.trino_catalog_relation_changed,
+            self._on_trino_catalog_changed,
+        )
+        charm.framework.observe(
+            charm.on.trino_catalog_relation_broken,
+            self._on_relation_broken,
+        )
+
+        self._access_token: Optional[str] = None
+
+    @property
+    def access_token(self) -> str:
+        """Return (and lazily create) a DataHub access token for ingestion.
+
+        Raises:
+            RuntimeError: If token creation fails.
+        """
+        if self._access_token is None:
+            self._access_token = _create_access_token(self.charm.system_client_secret)
+        return self._access_token
+
+    @log_event_handler(logger)
+    def _on_trino_catalog_changed(self, event) -> None:
+        """Handle trino-catalog relation changed events.
+
+        Args:
+            event: The event triggered when the relation changed.
+        """
+        if not self.charm.unit.is_leader():
+            return
+
+        if not self.charm._state.is_ready():
+            event.defer()
+            return
+
+        self.charm.unit.status = WaitingStatus("handling trino-catalog change")
+        self._reconcile_ingestions()
+        self.charm._update(event)
+
+    @log_event_handler(logger)
+    def _on_relation_broken(self, event) -> None:
+        """Handle broken relations with Trino.
+
+        Args:
+            event: The event triggered when the relation is broken.
+        """
+        if not self.charm.unit.is_leader():
+            return
+
+        if not self.charm._state.is_ready():
+            event.defer()
+            return
+
+        self._cleanup_managed_ingestions()
+        self.charm._update(event)
+
+    def _reconcile_ingestions(self) -> None:
+        """Reconcile Juju-managed Trino ingestion sources with current relation state."""
+        trino_info = self.trino_catalog.get_trino_info()
+        if not trino_info:
+            logger.info("No Trino info available, skipping reconciliation")
+            return
+
+        credentials = self.trino_catalog.get_credentials()
+        if not credentials:
+            logger.info("No Trino credentials available, skipping reconciliation")
+            return
+
+        username, password = credentials
+        trino_url = trino_info["trino_url"]
+        catalogs = trino_info["trino_catalogs"]
+
+        desired_catalogs = {catalog.name for catalog in catalogs}
+
+        try:
+            bearer = self.charm.system_client_secret
+            token = self.access_token
+
+            all_sources = _list_ingestion_sources(bearer)
+            managed = _filter_juju_managed(all_sources)
+        except Exception as e:
+            logger.error("Failed to fetch ingestion sources from DataHub: %s", str(e))
+            return
+
+        existing_by_catalog: Dict[str, Dict[str, Any]] = {}
+        for source in managed:
+            catalog_name = _extract_catalog_from_name(source["name"])
+            existing_by_catalog[catalog_name] = source
+
+        config = self.charm.config
+        params = _IngestionParams(
+            trino_url=trino_url,
+            username=username,
+            password=password,
+            access_token=token,
+            schema_pattern=config.schema_pattern,
+            table_pattern=config.table_pattern,
+            column_pattern=config.column_pattern,
+        )
+
+        self._create_missing_ingestions(desired_catalogs, existing_by_catalog, bearer, params)
+        self._update_existing_ingestions(desired_catalogs, existing_by_catalog, bearer, params)
+        self._delete_obsolete_ingestions(desired_catalogs, existing_by_catalog, bearer)
+
+    def _create_missing_ingestions(
+        self,
+        desired: Set[str],
+        existing: Dict[str, Dict[str, Any]],
+        bearer: str,
+        params: "_IngestionParams",
+    ) -> None:
+        """Create ingestion sources for catalogs not yet tracked."""
+        for catalog_name in desired - set(existing.keys()):
+            try:
+                urn = _create_ingestion_source(
+                    bearer,
+                    catalog_name,
+                    params,
+                )
+                logger.info("Created ingestion source for catalog '%s': %s", catalog_name, urn)
+            except Exception as e:
+                logger.error("Failed to create ingestion for catalog '%s': %s", catalog_name, str(e))
+
+    def _update_existing_ingestions(
+        self,
+        desired: Set[str],
+        existing: Dict[str, Dict[str, Any]],
+        bearer: str,
+        params: "_IngestionParams",
+    ) -> None:
+        """Update ingestion sources whose catalogs are still desired."""
+        for catalog_name in desired & set(existing.keys()):
+            source = existing[catalog_name]
+            try:
+                _update_ingestion_source(
+                    bearer,
+                    source["urn"],
+                    source,
+                    params,
+                )
+                logger.info("Updated ingestion source for catalog '%s'", catalog_name)
+            except Exception as e:
+                logger.error("Failed to update ingestion for catalog '%s': %s", catalog_name, str(e))
+
+    def _delete_obsolete_ingestions(
+        self,
+        desired: Set[str],
+        existing: Dict[str, Dict[str, Any]],
+        bearer: str,
+    ) -> None:
+        """Delete ingestion sources for catalogs no longer in the relation."""
+        for catalog_name in set(existing.keys()) - desired:
+            source = existing[catalog_name]
+            try:
+                _delete_ingestion_source(bearer, source["urn"])
+                logger.info("Deleted obsolete ingestion source for catalog '%s'", catalog_name)
+            except Exception as e:
+                logger.error("Failed to delete ingestion for catalog '%s': %s", catalog_name, str(e))
+
+    def _cleanup_managed_ingestions(self) -> None:
+        """Delete all Juju-managed Trino ingestion sources (relation-broken cleanup)."""
+        try:
+            bearer = self.charm.system_client_secret
+            all_sources = _list_ingestion_sources(bearer)
+            managed = _filter_juju_managed(all_sources)
+        except Exception as e:
+            logger.error("Failed to fetch ingestion sources during cleanup: %s", str(e))
+            return
+
+        for source in managed:
+            try:
+                _delete_ingestion_source(bearer, source["urn"])
+                logger.info("Cleaned up ingestion source '%s'", source["name"])
+            except Exception as e:
+                logger.error("Failed to clean up ingestion '%s': %s", source["name"], str(e))

--- a/src/relations/trino.py
+++ b/src/relations/trino.py
@@ -579,15 +579,62 @@ class TrinoRelation(framework.Object):
 
         self._access_token: Optional[str] = None  # type: ignore[annotation-unchecked]
 
+    def _get_stored_access_token(self) -> Optional[str]:
+        """Retrieve the persisted access token from the Juju secret store.
+
+        Returns:
+            The stored token string, or None if not yet persisted.
+        """
+        relation = self.charm.model.get_relation("peer")
+        if not relation:
+            return None
+        secret_id = relation.data[self.charm.app].get(literals.INGESTION_TOKEN_SECRET_LABEL)
+        if not secret_id:
+            return None
+        secret = self.charm.model.get_secret(id=secret_id)
+        return secret.peek_content().get("token")
+
+    def _store_access_token(self, token: str) -> None:
+        """Persist an access token in the Juju secret store.
+
+        Creates the secret on first call; updates the existing secret on subsequent calls.
+
+        Args:
+            token: The access token to store.
+        """
+        relation = self.charm.model.get_relation("peer")
+        if not relation:
+            return
+        content = {"token": token}
+        secret_id = relation.data[self.charm.app].get(literals.INGESTION_TOKEN_SECRET_LABEL)
+        if secret_id:
+            secret = self.charm.model.get_secret(id=secret_id)
+            secret.set_content(content)
+        else:
+            secret = self.charm.app.add_secret(content, label=literals.INGESTION_TOKEN_SECRET_LABEL)
+            relation.data[self.charm.app][literals.INGESTION_TOKEN_SECRET_LABEL] = secret.id
+
     @property
     def access_token(self) -> str:
         """Return (and lazily create) a DataHub access token for ingestion.
 
+        Checks the in-memory cache first, then the Juju secret store,
+        and only creates a new token via the DataHub API as a last resort.
+
         Raises:
             RuntimeError: If token creation fails.
         """
-        if self._access_token is None:
-            self._access_token = _create_access_token(self.charm.system_client_id, self.charm.system_client_secret)
+        if self._access_token is not None:
+            return self._access_token
+
+        stored = self._get_stored_access_token()
+        if stored:
+            self._access_token = stored
+            return self._access_token
+
+        token = _create_access_token(self.charm.system_client_id, self.charm.system_client_secret)
+        self._access_token = token
+        self._store_access_token(token)
         return self._access_token
 
     @log_event_handler(logger)
@@ -695,6 +742,9 @@ class TrinoRelation(framework.Object):
                 if attempt == 0:
                     logger.info("Authentication failed, refreshing token and retrying")
                     self._access_token = None
+                    token = _create_access_token(self.charm.system_client_id, self.charm.system_client_secret)
+                    self._access_token = token
+                    self._store_access_token(token)
                     continue
                 logger.error("Authentication failed after token refresh")
             except Exception as e:

--- a/src/relations/trino.py
+++ b/src/relations/trino.py
@@ -168,7 +168,7 @@ def _is_https(trino_url: str) -> bool:
 
     The catalog interface does not pass the scheme so we determine it
     based on the current conventions.
-    
+
     Args:
         trino_url: Trino URL in host:port format.
 
@@ -512,7 +512,7 @@ class TrinoRelation(framework.Object):
         result = self._prepare_ingestion_state(catalogs, password)
         if result is None:
             return
-        access_token, managed = result
+        access_token, managed, secrets_map = result
 
         existing_by_catalog: Dict[str, Dict[str, Any]] = {}
         for source in managed:
@@ -529,7 +529,7 @@ class TrinoRelation(framework.Object):
 
         self._create_missing_ingestions(desired_catalogs, existing_by_catalog, access_token, params)
         self._update_existing_ingestions(desired_catalogs, existing_by_catalog, access_token, params)
-        self._delete_obsolete_ingestions(desired_catalogs, existing_by_catalog, access_token)
+        self._delete_obsolete_ingestions(desired_catalogs, existing_by_catalog, access_token, secrets_map)
 
     def _prepare_ingestion_state(self, catalogs, password: str) -> Optional[tuple]:
         """Ensure secrets exist and fetch managed ingestion sources, retrying on auth failure.
@@ -539,7 +539,7 @@ class TrinoRelation(framework.Object):
             password: Current Trino password for per-catalog secrets.
 
         Returns:
-            Tuple of (access_token, managed_sources) or None on failure.
+            Tuple of (access_token, managed_sources, secrets_map) or None on failure.
         """
         for attempt in range(2):
             try:
@@ -550,7 +550,7 @@ class TrinoRelation(framework.Object):
                     graphql.ensure_secret(access_token, _normalize_secret_name(catalog.name), password, secrets_map)
                 all_sources = graphql.list_ingestion_sources(access_token)
                 managed = _filter_juju_managed(all_sources)
-                return access_token, managed
+                return access_token, managed, secrets_map
             except graphql.AuthenticationError:
                 if attempt == 0:
                     logger.info("Authentication failed, refreshing token and retrying")
@@ -610,8 +610,9 @@ class TrinoRelation(framework.Object):
         desired: Set[str],
         existing: Dict[str, Dict[str, Any]],
         bearer: str,
+        secrets_map: Dict[str, str],
     ) -> None:
-        """Delete ingestion sources for catalogs no longer in the relation."""
+        """Delete ingestion sources and their secrets for catalogs no longer in the relation."""
         for catalog_name in set(existing.keys()) - desired:
             source = existing[catalog_name]
             try:
@@ -619,13 +620,22 @@ class TrinoRelation(framework.Object):
                 logger.info("Deleted obsolete ingestion source for catalog '%s'", catalog_name)
             except Exception as e:
                 logger.error("Failed to delete ingestion for catalog '%s': %s", catalog_name, str(e))
+            secret_name = _normalize_secret_name(catalog_name)
+            secret_urn = secrets_map.get(secret_name)
+            if secret_urn:
+                try:
+                    graphql.delete_secret(bearer, secret_urn)
+                    logger.info("Deleted secret '%s' for catalog '%s'", secret_name, catalog_name)
+                except Exception as e:
+                    logger.error("Failed to delete secret for catalog '%s': %s", catalog_name, str(e))
 
     def _cleanup_managed_ingestions(self) -> None:
-        """Delete all Juju-managed Trino ingestion sources (relation-broken cleanup)."""
+        """Delete all Juju-managed Trino ingestion sources and secrets (relation-broken cleanup)."""  # noqa W505
         try:
             access_token = self.access_token
             all_sources = graphql.list_ingestion_sources(access_token)
             managed = _filter_juju_managed(all_sources)
+            secrets_map = graphql.list_secrets(access_token)
         except Exception as e:
             logger.error("Failed to fetch ingestion sources during cleanup: %s", str(e))
             return
@@ -636,3 +646,11 @@ class TrinoRelation(framework.Object):
                 logger.info("Cleaned up ingestion source '%s'", source["name"])
             except Exception as e:
                 logger.error("Failed to clean up ingestion '%s': %s", source["name"], str(e))
+
+        for secret_name, secret_urn in secrets_map.items():
+            if secret_name == GMS_TOKEN_SECRET_NAME or secret_name.startswith(TRINO_PASSWORD_SECRET_PREFIX):
+                try:
+                    graphql.delete_secret(access_token, secret_urn)
+                    logger.info("Cleaned up secret '%s'", secret_name)
+                except Exception as e:
+                    logger.error("Failed to clean up secret '%s': %s", secret_name, str(e))

--- a/src/relations/trino.py
+++ b/src/relations/trino.py
@@ -163,6 +163,27 @@ def _normalize_secret_name(catalog_name: str) -> str:
     return f"{TRINO_PASSWORD_SECRET_PREFIX}{normalized}"
 
 
+def _is_https(trino_url: str) -> bool:
+    """Determine whether a Trino connection uses HTTPS based on the port.
+
+    The catalog interface does not pass the scheme so we determine it
+    based on the current conventions.
+    
+    Args:
+        trino_url: Trino URL in host:port format.
+
+    Returns:
+        True if port is 443, False otherwise.
+    """
+    parts = trino_url.rsplit(":", 1)
+    if len(parts) != 2:
+        return False
+    try:
+        return int(parts[1]) == 443
+    except ValueError:
+        return False
+
+
 def _build_recipe(
     catalog_name: str,
     params: "_IngestionParams",
@@ -183,20 +204,24 @@ def _build_recipe(
     """
     default_pattern = {"allow": [".*"], "deny": []}
     patterns = patterns_override if patterns_override is not None else params.trino_patterns
+    source_config = {
+        "host_port": params.trino_url,
+        "database": catalog_name,
+        "username": params.username,
+        "schema_pattern": patterns.get("schema-pattern", default_pattern),
+        "table_pattern": patterns.get("table-pattern", default_pattern),
+        "view_pattern": patterns.get("view-pattern", default_pattern),
+        "env": "PROD",
+        "stateful_ingestion": {"enabled": True},
+    }
+    # Password only works over HTTPS; omit it for plain HTTP connections.
+    if _is_https(params.trino_url):
+        source_config["password"] = f"${{{_normalize_secret_name(catalog_name)}}}"
+
     recipe = {
         "source": {
             "type": "trino",
-            "config": {
-                "host_port": params.trino_url,
-                "database": catalog_name,
-                "username": params.username,
-                "password": f"${{{_normalize_secret_name(catalog_name)}}}",
-                "schema_pattern": patterns.get("schema-pattern", default_pattern),
-                "table_pattern": patterns.get("table-pattern", default_pattern),
-                "view_pattern": patterns.get("view-pattern", default_pattern),
-                "env": "PROD",
-                "stateful_ingestion": {"enabled": True},
-            },
+            "config": source_config,
         },
         "sink": {
             "type": "datahub-rest",

--- a/src/relations/trino.py
+++ b/src/relations/trino.py
@@ -442,7 +442,6 @@ class TrinoRelation(framework.Object):
             return
 
         if not self.charm._state.is_ready():
-            event.defer()
             return
 
         self.charm.unit.status = WaitingStatus("handling trino-catalog change")
@@ -460,7 +459,6 @@ class TrinoRelation(framework.Object):
             return
 
         if not self.charm._state.is_ready():
-            event.defer()
             return
 
         self._cleanup_managed_ingestions()

--- a/src/relations/trino.py
+++ b/src/relations/trino.py
@@ -131,14 +131,16 @@ def _build_recipe(catalog_name: str, params: "_IngestionParams") -> str:
 def _graphql_request(
     query: str,
     variables: Optional[Dict[str, Any]],
-    bearer_token: str,
+    token: str,
+    auth_scheme: str = "Bearer",
 ) -> Dict[str, Any]:
     """Execute a GraphQL request against the DataHub GMS endpoint.
 
     Args:
         query: GraphQL query or mutation string.
         variables: Optional variables for the query.
-        bearer_token: Bearer token for authentication.
+        token: Authentication token or credentials.
+        auth_scheme: HTTP auth scheme (e.g. "Bearer" or "Basic").
 
     Returns:
         The parsed JSON response body.
@@ -147,7 +149,7 @@ def _graphql_request(
         RuntimeError: If the request fails or returns GraphQL errors.
     """
     headers = {
-        "Authorization": f"Bearer {bearer_token}",
+        "Authorization": f"{auth_scheme} {token}",
         "Content-Type": "application/json",
     }
     payload: Dict[str, Any] = {"query": query}
@@ -164,11 +166,14 @@ def _graphql_request(
     return body
 
 
-def _create_access_token(bearer_token: str) -> str:
+def _create_access_token(system_client_id: str, system_client_secret: str) -> str:
     """Create a DataHub access token for the system user.
 
+    Uses Basic auth with system client credentials to bootstrap a token.
+
     Args:
-        bearer_token: System client secret used as bearer for this request.
+        system_client_id: DataHub system client identifier.
+        system_client_secret: DataHub system client secret.
 
     Returns:
         The generated access token string.
@@ -188,7 +193,8 @@ def _create_access_token(bearer_token: str) -> str:
             "name": "juju-managed-ingestion-token",
         }
     }
-    body = _graphql_request(query, variables, bearer_token)
+    basic_credentials = f"{system_client_id}:{system_client_secret}"
+    body = _graphql_request(query, variables, basic_credentials, auth_scheme="Basic")
     return body["data"]["createAccessToken"]["accessToken"]
 
 
@@ -433,7 +439,7 @@ class TrinoRelation(framework.Object):
             RuntimeError: If token creation fails.
         """
         if self._access_token is None:
-            self._access_token = _create_access_token(self.charm.system_client_secret)
+            self._access_token = _create_access_token(self.charm.system_client_id, self.charm.system_client_secret)
         return self._access_token
 
     @log_event_handler(logger)
@@ -490,10 +496,9 @@ class TrinoRelation(framework.Object):
         desired_catalogs = {catalog.name for catalog in catalogs}
 
         try:
-            bearer = self.charm.system_client_secret
-            token = self.access_token
+            access_token = self.access_token
 
-            all_sources = _list_ingestion_sources(bearer)
+            all_sources = _list_ingestion_sources(access_token)
             managed = _filter_juju_managed(all_sources)
         except Exception as e:
             logger.error("Failed to fetch ingestion sources from DataHub: %s", str(e))
@@ -509,15 +514,15 @@ class TrinoRelation(framework.Object):
             trino_url=trino_url,
             username=username,
             password=password,
-            access_token=token,
+            access_token=access_token,
             schema_pattern=config.schema_pattern,
             table_pattern=config.table_pattern,
             column_pattern=config.column_pattern,
         )
 
-        self._create_missing_ingestions(desired_catalogs, existing_by_catalog, bearer, params)
-        self._update_existing_ingestions(desired_catalogs, existing_by_catalog, bearer, params)
-        self._delete_obsolete_ingestions(desired_catalogs, existing_by_catalog, bearer)
+        self._create_missing_ingestions(desired_catalogs, existing_by_catalog, access_token, params)
+        self._update_existing_ingestions(desired_catalogs, existing_by_catalog, access_token, params)
+        self._delete_obsolete_ingestions(desired_catalogs, existing_by_catalog, access_token)
 
     def _create_missing_ingestions(
         self,
@@ -577,8 +582,8 @@ class TrinoRelation(framework.Object):
     def _cleanup_managed_ingestions(self) -> None:
         """Delete all Juju-managed Trino ingestion sources (relation-broken cleanup)."""
         try:
-            bearer = self.charm.system_client_secret
-            all_sources = _list_ingestion_sources(bearer)
+            access_token = self.access_token
+            all_sources = _list_ingestion_sources(access_token)
             managed = _filter_juju_managed(all_sources)
         except Exception as e:
             logger.error("Failed to fetch ingestion sources during cleanup: %s", str(e))
@@ -586,7 +591,7 @@ class TrinoRelation(framework.Object):
 
         for source in managed:
             try:
-                _delete_ingestion_source(bearer, source["urn"])
+                _delete_ingestion_source(access_token, source["urn"])
                 logger.info("Cleaned up ingestion source '%s'", source["name"])
             except Exception as e:
                 logger.error("Failed to clean up ingestion '%s': %s", source["name"], str(e))

--- a/src/relations/trino.py
+++ b/src/relations/trino.py
@@ -121,6 +121,35 @@ def _build_managed_extra_args() -> List[Dict[str, str]]:
     return [{"key": "extra_env_vars", "value": json.dumps(env_vars)}]
 
 
+def _extract_patterns(source: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Extract filter patterns from an existing ingestion source's recipe.
+
+    Args:
+        source: Ingestion source dict from the GraphQL response.
+
+    Returns:
+        Patterns dict with keys like "schema-pattern", or None if not parseable.
+    """
+    recipe_str = source.get("config", {}).get("recipe")
+    if not recipe_str:
+        return None
+    try:
+        recipe = json.loads(recipe_str)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    config = recipe.get("source", {}).get("config", {})
+    key_map = {
+        "schema_pattern": "schema-pattern",
+        "table_pattern": "table-pattern",
+        "view_pattern": "view-pattern",
+    }
+    patterns = {}
+    for recipe_key, pattern_key in key_map.items():
+        if recipe_key in config:
+            patterns[pattern_key] = config[recipe_key]
+    return patterns or None
+
+
 def _normalize_secret_name(catalog_name: str) -> str:
     """Build a DataHub secret name for a catalog's Trino password.
 
@@ -134,7 +163,11 @@ def _normalize_secret_name(catalog_name: str) -> str:
     return f"{TRINO_PASSWORD_SECRET_PREFIX}{normalized}"
 
 
-def _build_recipe(catalog_name: str, params: "_IngestionParams") -> str:
+def _build_recipe(
+    catalog_name: str,
+    params: "_IngestionParams",
+    patterns_override: Optional[Dict[str, Any]] = None,
+) -> str:
     """Build a DataHub ingestion recipe YAML string for a Trino catalog.
 
     Credentials are referenced via DataHub-managed secret placeholders
@@ -143,12 +176,13 @@ def _build_recipe(catalog_name: str, params: "_IngestionParams") -> str:
     Args:
         catalog_name: Trino catalog name (used as the database field).
         params: Common ingestion parameters.
+        patterns_override: If provided, use these patterns instead of params.trino_patterns.
 
     Returns:
         JSON-encoded recipe string.
     """
     default_pattern = {"allow": [".*"], "deny": []}
-    patterns = params.trino_patterns
+    patterns = patterns_override if patterns_override is not None else params.trino_patterns
     recipe = {
         "source": {
             "type": "trino",
@@ -178,9 +212,6 @@ def _build_recipe(catalog_name: str, params: "_IngestionParams") -> str:
 def _filter_juju_managed(sources: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """Filter ingestion sources to those marked as Juju-managed.
 
-    Supports both the current extra_env_vars JSON format and the legacy
-    top-level JUJU_MANAGED key for migration compatibility.
-
     Args:
         sources: List of ingestion source dicts from the GraphQL response.
 
@@ -191,20 +222,15 @@ def _filter_juju_managed(sources: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     for source in sources:
         extra_args = source.get("config", {}).get("extraArgs") or []
         for arg in extra_args:
-            key = arg.get("key")
-            # Current format: JUJU_MANAGED inside extra_env_vars JSON
-            if key == "extra_env_vars":
-                try:
-                    env_vars = json.loads(arg.get("value", "{}"))
-                    if env_vars.get(JUJU_MANAGED_KEY) == "true":
-                        managed.append(source)
-                        break
-                except (json.JSONDecodeError, TypeError):
-                    pass
-            # Legacy format: top-level JUJU_MANAGED key
-            if key == JUJU_MANAGED_KEY and arg.get("value") == "True":
-                managed.append(source)
-                break
+            if arg.get("key") != "extra_env_vars":
+                continue
+            try:
+                env_vars = json.loads(arg.get("value", "{}"))
+                if env_vars.get(JUJU_MANAGED_KEY) == "true":
+                    managed.append(source)
+            except (json.JSONDecodeError, TypeError):
+                logger.warning("Malformed extra_env_vars JSON in source '%s'", source.get("name"))
+            break
     return managed
 
 
@@ -236,7 +262,7 @@ def _create_ingestion_source(
         },
         "config": {
             "recipe": recipe,
-            "executorId": "default",
+            "executorId": literals.DEFAULT_EXECUTOR_ID,
             "extraArgs": extra_args_list,
         },
     }
@@ -251,7 +277,7 @@ def _update_ingestion_source(
 ) -> None:
     """Update credentials and proxy vars of an existing ingestion source.
 
-    Preserves name, type, description, schedule, and other settings.
+    Preserves name, type, description, schedule, patterns, and other settings.
 
     Args:
         bearer_token: Bearer token for authentication.
@@ -259,11 +285,25 @@ def _update_ingestion_source(
         existing_source: Current source dict from listIngestionSources.
         params: Common ingestion parameters.
     """
-    recipe = _build_recipe(_extract_catalog_from_name(existing_source["name"]), params)
+    existing_patterns = _extract_patterns(existing_source)
+    recipe = _build_recipe(
+        _extract_catalog_from_name(existing_source["name"]),
+        params,
+        patterns_override=existing_patterns,
+    )
 
     # Preserve non-managed extraArgs; replace the managed extra_env_vars block atomically.
     existing_extra = existing_source.get("config", {}).get("extraArgs") or []
-    managed_keys = {JUJU_MANAGED_KEY, "extra_env_vars", "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"}
+    managed_keys = {
+        JUJU_MANAGED_KEY,
+        "extra_env_vars",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "NO_PROXY",
+        "http_proxy",
+        "https_proxy",
+        "no_proxy",
+    }
     preserved = [a for a in existing_extra if a.get("key") not in managed_keys]
     preserved.extend(_build_managed_extra_args())
 
@@ -280,7 +320,7 @@ def _update_ingestion_source(
         "type": existing_source.get("type", "trino"),
         "config": {
             "recipe": recipe,
-            "executorId": existing_source.get("config", {}).get("executorId", "default"),
+            "executorId": existing_source.get("config", {}).get("executorId", literals.DEFAULT_EXECUTOR_ID),
             "extraArgs": preserved,
         },
     }
@@ -346,7 +386,7 @@ class TrinoRelation(framework.Object):
         if not secret_id:
             return None
         secret = self.charm.model.get_secret(id=secret_id)
-        return secret.peek_content().get("token")
+        return secret.get_content(refresh=True).get("token")
 
     def _store_access_token(self, token: str) -> None:
         """Persist an access token in the Juju secret store.
@@ -406,7 +446,7 @@ class TrinoRelation(framework.Object):
             return
 
         self.charm.unit.status = WaitingStatus("handling trino-catalog change")
-        self._reconcile_ingestions()
+        self.reconcile_ingestions()
         self.charm._update(event)
 
     @log_event_handler(logger)
@@ -426,7 +466,7 @@ class TrinoRelation(framework.Object):
         self._cleanup_managed_ingestions()
         self.charm._update(event)
 
-    def _reconcile_ingestions(self) -> None:
+    def reconcile_ingestions(self) -> None:
         """Reconcile Juju-managed Trino ingestion sources with current relation state."""
         trino_info = self.trino_catalog.get_trino_info()
         if not trino_info:
@@ -444,11 +484,7 @@ class TrinoRelation(framework.Object):
         desired_catalogs = {catalog.name for catalog in catalogs}
 
         config = self.charm.config
-        try:
-            trino_patterns = json.loads(config.trino_patterns)
-        except (json.JSONDecodeError, TypeError) as e:
-            logger.error("Invalid trino-patterns config: %s", str(e))
-            return
+        trino_patterns = json.loads(config.trino_patterns)
 
         result = self._prepare_ingestion_state(catalogs, password)
         if result is None:

--- a/src/services.py
+++ b/src/services.py
@@ -276,6 +276,8 @@ class ActionsService(AbstractService):
             context.charm._state.ran_upgrade,
             utils.get_from_optional_dict(context.charm._state.kafka_connection, "initialized"),
             GMSService.is_enabled(context),
+            context.charm.system_client_id,
+            context.charm.system_client_secret,
         )
         return all(checks)
 

--- a/src/services.py
+++ b/src/services.py
@@ -671,6 +671,10 @@ class GMSService(AbstractService):
             env["INDEX_PREFIX"] = context.charm.config.opensearch_index_prefix
         kafka_env = _kafka_topic_names(context.charm.config.kafka_topic_prefix)
         env.update(kafka_env)
+
+        env["DATAHUB_SYSTEM_CLIENT_ID"] = context.charm.system_client_id
+        env["DATAHUB_SYSTEM_CLIENT_SECRET"] = context.charm.system_client_secret
+
         return env
 
     @classmethod

--- a/src/services.py
+++ b/src/services.py
@@ -24,6 +24,8 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Dict, List, Optional
 from urllib.parse import urlparse
 
+import yaml
+
 import exceptions
 import literals
 import utils
@@ -357,7 +359,10 @@ class FrontendService(AbstractService):
             Whether the service should be enabled.
         """
         is_ready = cls.is_ready(context)
-        checks = (context.charm._state.frontend_truststore_initialized is True,)
+        checks = (
+            context.charm._state.frontend_user_props_initialized is True,
+            context.charm._state.frontend_truststore_initialized is True,
+        )
         return is_ready and all(checks)
 
     @classmethod
@@ -501,6 +506,10 @@ class FrontendService(AbstractService):
     def run_initialization(cls, context: ServiceContext) -> bool:
         """Run service specific initialization scripts if service is ready and it is necessary.
 
+        Initialization runs in order:
+        1. Push user.props credential file
+        2. Truststore initialization for Opensearch SSL
+
         Args:
             context: Context for the service.
 
@@ -514,28 +523,38 @@ class FrontendService(AbstractService):
             logger.info("datahub-frontend is not ready to be initialized, skipping initialization")
             return False
 
-        # The only initialization step currently is to set up truststore for Opensearch SSL.
-        check_frontend_truststore = context.charm._state.frontend_truststore_initialized is True
-        if check_frontend_truststore:
+        user_props_done = context.charm._state.frontend_user_props_initialized is True
+        truststore_done = context.charm._state.frontend_truststore_initialized is True
+        if user_props_done and truststore_done:
             logger.debug("datahub-frontend is already initialized, skipping initialization")
             return False
 
-        certificates = context.charm._state.opensearch_connection["tls-ca"]
-
         container = context.charm.unit.get_container(cls.name)
 
-        try:
-            _import_certificates_to_truststore(
-                container,
-                certificates,
-                literals.OPENSEARCH_ROOT_CA_CERT_ALIAS,
-            )
-        except Exception as e:
-            logger.info("Failed to initialize truststore for datahub-frontend: '%s'", str(e))
-            raise exceptions.InitializationFailedError("failed to initialize truststores for datahub-frontend")
+        # Step 1: Push user.props credential file.
+        if not user_props_done:
+            password = context.charm._ensure_password()
+            if not password:
+                logger.info("Admin password not yet available, skipping frontend initialization")
+                return False
+            utils.push_contents_to_file(container, f"datahub:{password}", "/datahub-frontend/conf/user.props", 0o644)
+            context.charm._state.frontend_user_props_initialized = True
 
-        logger.info("Successful truststore initialization for datahub-frontend")
-        context.charm._state.frontend_truststore_initialized = True
+        # Step 2: Truststore initialization for Opensearch SSL.
+        if not truststore_done:
+            certificates = context.charm._state.opensearch_connection["tls-ca"]
+            try:
+                _import_certificates_to_truststore(
+                    container,
+                    certificates,
+                    literals.OPENSEARCH_ROOT_CA_CERT_ALIAS,
+                )
+            except Exception as e:
+                logger.info("Failed to initialize truststore for datahub-frontend: '%s'", str(e))
+                raise exceptions.InitializationFailedError("failed to initialize truststores for datahub-frontend")
+            logger.info("Successful truststore initialization for datahub-frontend")
+            context.charm._state.frontend_truststore_initialized = True
+
         return True
 
 
@@ -688,11 +707,38 @@ class GMSService(AbstractService):
         return env
 
     @classmethod
+    def _set_workload_version(cls, context: ServiceContext) -> None:
+        """Extract and set the workload version from the GMS container's rockcraft.yaml.
+
+        Guarded by a state flag so it runs at most once per container lifecycle.
+        On failure, the flag stays unset so the operation retries on the next _update call.
+
+        Args:
+            context: Context for the service.
+        """
+        if context.charm._state.gms_workload_version_set is True:
+            return
+
+        container = context.charm.unit.get_container(cls.name)
+        try:
+            meta_file = container.pull("/rockcraft.yaml")
+            meta = yaml.safe_load(meta_file)
+            if not meta or "version" not in meta:
+                raise ValueError("Cannot find 'version' in 'rockcraft.yaml'.")
+            context.charm.unit.set_workload_version(meta["version"])
+        except Exception as e:
+            logger.warning("Could not set workload version: %s", str(e))
+            return
+
+        context.charm._state.gms_workload_version_set = True
+
+    @classmethod
     def run_initialization(cls, context: ServiceContext) -> bool:
         """Run all initialization steps for the GMS container.
 
         The GMS rock bundles all setup scripts (PostgreSQL, Opensearch, upgrade)
         in addition to the GMS service itself. Initialization runs in order:
+        0. Workload version extraction (safe, no relation dependencies)
         1. PostgreSQL setup (init.sh)
         2. Opensearch index creation (create-indices.sh)
         3. Truststore initialization for Opensearch SSL
@@ -704,6 +750,9 @@ class GMSService(AbstractService):
         Returns:
             If initialization scripts were run and were successful.
         """
+        # Workload version is a safe read-only operation that doesn't require relations.
+        cls._set_workload_version(context)
+
         if not cls.is_ready(context):
             logger.info("datahub-gms is not ready to be initialized, skipping initialization")
             return False

--- a/src/services.py
+++ b/src/services.py
@@ -1,5 +1,6 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
+# pylint: disable=C0302
 
 """Define DataHub services."""
 
@@ -320,6 +321,10 @@ class ActionsService(AbstractService):
         kafka_env = _kafka_topic_names(context.charm.config.kafka_topic_prefix)
         env.update(kafka_env)
         env.update(_compile_standard_proxy_environment(extra_no_proxy_hosts=["localhost", env["DATAHUB_GMS_HOST"]]))
+
+        env["DATAHUB_SYSTEM_CLIENT_ID"] = context.charm.system_client_id
+        env["DATAHUB_SYSTEM_CLIENT_SECRET"] = context.charm.system_client_secret
+
         return env
 
 
@@ -455,6 +460,9 @@ class FrontendService(AbstractService):
 
         proxy_vars["HTTP_NON_PROXY_HOSTS"] = "|".join(no_proxy_hosts)
         env.update(proxy_vars)
+
+        env["DATAHUB_SYSTEM_CLIENT_ID"] = context.charm.system_client_id
+        env["DATAHUB_SYSTEM_CLIENT_SECRET"] = context.charm.system_client_secret
 
         # Set up OIDC if needed.
         if context.charm.config.oidc_secret_id is None:

--- a/src/structured_config.py
+++ b/src/structured_config.py
@@ -3,6 +3,7 @@
 
 """Structured configuration for the charm."""
 
+import json
 import logging
 from typing import Optional
 
@@ -10,6 +11,15 @@ from charms.data_platform_libs.v0.data_models import BaseConfigModel
 from pydantic import field_validator
 
 logger = logging.getLogger(__name__)
+
+_DEFAULT_PATTERN = {"allow": [".*"], "deny": []}
+_TRINO_PATTERNS_DEFAULT = json.dumps(
+    {
+        "schema-pattern": _DEFAULT_PATTERN,
+        "table-pattern": _DEFAULT_PATTERN,
+        "view-pattern": _DEFAULT_PATTERN,
+    }
+)
 
 
 class CharmConfig(BaseConfigModel):
@@ -26,9 +36,7 @@ class CharmConfig(BaseConfigModel):
         external_fe_hostname: Hostname of frontend visible to outside.
         external_gms_hostname: Hostname of GMS visible to outside.
         tls_secret_name: Name of the k8s secret to use for the TLS certificate.
-        schema_pattern: JSON pattern string for Trino ingestion schema filtering.
-        table_pattern: JSON pattern string for Trino ingestion table filtering.
-        column_pattern: JSON pattern string for Trino ingestion column filtering.
+        trino_patterns: JSON string with schema, table, and view filter patterns.
     """
 
     auth_verbose_logging: bool = False
@@ -40,9 +48,7 @@ class CharmConfig(BaseConfigModel):
     external_fe_hostname: Optional[str] = None
     external_gms_hostname: Optional[str] = None
     tls_secret_name: Optional[str] = None
-    schema_pattern: str = '{"allow":[".*"],"deny":[]}'
-    table_pattern: str = '{"allow":[".*"],"deny":[]}'
-    column_pattern: str = '{"allow":[".*"],"deny":[]}'
+    trino_patterns: str = _TRINO_PATTERNS_DEFAULT
 
     @field_validator("*", mode="before")
     @classmethod

--- a/src/structured_config.py
+++ b/src/structured_config.py
@@ -26,6 +26,9 @@ class CharmConfig(BaseConfigModel):
         external_fe_hostname: Hostname of frontend visible to outside.
         external_gms_hostname: Hostname of GMS visible to outside.
         tls_secret_name: Name of the k8s secret to use for the TLS certificate.
+        schema_pattern: JSON pattern string for Trino ingestion schema filtering.
+        table_pattern: JSON pattern string for Trino ingestion table filtering.
+        column_pattern: JSON pattern string for Trino ingestion column filtering.
     """
 
     auth_verbose_logging: bool = False
@@ -37,6 +40,9 @@ class CharmConfig(BaseConfigModel):
     external_fe_hostname: Optional[str] = None
     external_gms_hostname: Optional[str] = None
     tls_secret_name: Optional[str] = None
+    schema_pattern: str = '{"allow":[".*"],"deny":[]}'
+    table_pattern: str = '{"allow":[".*"],"deny":[]}'
+    column_pattern: str = '{"allow":[".*"],"deny":[]}'
 
     @field_validator("*", mode="before")
     @classmethod

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -28,6 +28,9 @@ def _get_password(juju: jubilant.Juju) -> str:
 @pytest.fixture(scope="module")
 def full_stack(k8s_juju: jubilant.Juju, lxd_juju: jubilant.Juju, charm: Path, rock_resources: dict) -> jubilant.Juju:
     """Deploy full dependency stack and return deployed K8s model handle."""
+    logger.info("Deploying '%s'", helpers.APP_NAME)
+    helpers.deploy_charm(k8s_juju, charm, rock_resources)
+
     logger.info("Deploying LXD dependencies")
     lxd_juju.deploy(helpers.KAFKA_NAME, channel=helpers.KAFKA_CHANNEL, revision=helpers.KAFKA_REVISION)
     lxd_juju.deploy(
@@ -78,17 +81,6 @@ def full_stack(k8s_juju: jubilant.Juju, lxd_juju: jubilant.Juju, charm: Path, ro
     lxd_juju.offer(helpers.OPENSEARCH_NAME, endpoint="opensearch-client", name=helpers.OPENSEARCH_OFFER_NAME)
     lxd_juju.offer(helpers.POSTGRES_NAME, endpoint="database", name=helpers.POSTGRES_OFFER_NAME)
 
-    logger.info("Deploying '%s'", helpers.APP_NAME)
-    helpers.deploy_charm(k8s_juju, charm, rock_resources)
-    helpers.wait_for_apps_status(
-        k8s_juju,
-        {
-            helpers.APP_NAME: ("blocked", "waiting", "maintenance", "active"),
-        },
-        timeout=20 * 60,
-        raise_on_error=False,
-    )
-
     lxd_model = helpers.model_short_name(lxd_juju.model or "")
     if not lxd_model:
         raise ValueError("Could not determine LXD model name")
@@ -98,6 +90,16 @@ def full_stack(k8s_juju: jubilant.Juju, lxd_juju: jubilant.Juju, charm: Path, ro
     k8s_juju.consume(f"{lxd_model}.{helpers.OPENSEARCH_OFFER_NAME}")
     k8s_juju.consume(f"{lxd_model}.{helpers.POSTGRES_OFFER_NAME}")
 
+    logger.info("Waiting for K8s applications to settle")
+    helpers.wait_for_apps_status(
+        k8s_juju,
+        {
+            helpers.APP_NAME: ("blocked", "waiting", "maintenance", "active"),
+        },
+        timeout=20 * 60,
+        raise_on_error=False,
+    )
+    
     logger.info("Integrating consumed offers")
     k8s_juju.integrate(f"{helpers.APP_NAME}:kafka", helpers.KAFKA_OFFER_NAME)
     k8s_juju.integrate(f"{helpers.APP_NAME}:opensearch", helpers.OPENSEARCH_OFFER_NAME)
@@ -129,7 +131,7 @@ def test_deploy_full(full_stack: jubilant.Juju):
     logger.info("Fetching admin password")
     admin_pwd = _get_password(full_stack)
 
-    url = f"{base_url}/logIn"
+    url = f"{base_url}/login"
 
     def _can_login(_: jubilant.Status) -> bool:
         """Attempt login and return True on success."""

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -131,16 +131,31 @@ def test_deploy_full(full_stack: jubilant.Juju):
     logger.info("Fetching admin password")
     admin_pwd = _get_password(full_stack)
 
-    url = f"{base_url}/login"
+    url = f"{base_url}/logIn"
+    logger.info("Testing against URL: %s", url)
 
     def _can_login(_: jubilant.Status) -> bool:
         """Attempt login and return True on success."""
         try:
             response = requests.post(url, json={"username": "datahub", "password": admin_pwd}, timeout=10)
-        except requests.RequestException:
-            return False
-        return response.status_code == 200
 
+            if response.status_code == 200:
+                return True
+
+            logger.info(
+                "Login failed | Status: %d | Body: %s | Headers: %s",
+                response.status_code,
+                response.text[:500],  # Truncate to avoid flooding logs
+                response.headers,
+            )
+            return False
+
+        except requests.RequestException as e:
+            # This catches connection errors, timeouts, and DNS issues
+            logger.info("Login connection error: %s", str(e))
+            return False
+
+    logger.info("Waiting for frontend to be ready")
     full_stack.wait(_can_login, timeout=15 * 60, delay=10, successes=1)
 
     response = requests.post(url, json={"username": "datahub", "password": admin_pwd}, timeout=10)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -99,7 +99,7 @@ def full_stack(k8s_juju: jubilant.Juju, lxd_juju: jubilant.Juju, charm: Path, ro
         timeout=20 * 60,
         raise_on_error=False,
     )
-    
+
     logger.info("Integrating consumed offers")
     k8s_juju.integrate(f"{helpers.APP_NAME}:kafka", helpers.KAFKA_OFFER_NAME)
     k8s_juju.integrate(f"{helpers.APP_NAME}:opensearch", helpers.OPENSEARCH_OFFER_NAME)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -48,6 +48,9 @@ class TestGetPasswordAction:
         assert "cannot read password secret" in exc_info.value.message
 
 
+_SECRET_ID = "test-encryption-secret-id"  # nosec B105
+
+
 class TestCheckStateSecretAccess:
     """Tests for secret-access failure handling in _check_state."""
 
@@ -140,3 +143,40 @@ class TestSecretChanged:
 
         assert isinstance(state_out.unit_status, testing.BlockedStatus)
         assert "encryption-keys-secret-id" in state_out.unit_status.message
+
+
+class TestSystemClientSecret:
+    """Tests for system client secret persistence lifecycle."""
+
+    def test_returns_empty_without_peer_relation(self, charm_ctx):
+        """Returns empty string when peer relation is not yet available."""
+        state = testing.State(
+            config={"encryption-keys-secret-id": _SECRET_ID},
+            leader=True,
+        )
+        with charm_ctx(charm_ctx.on.update_status(), state) as mgr:
+            assert mgr.charm.system_client_secret == ""  # nosec B105
+
+    def test_leader_creates_secret_on_first_access(self, charm_ctx):
+        """Leader creates an app-owned secret and returns its value on first access."""
+        peer = testing.PeerRelation(endpoint="peer")
+        state = testing.State(
+            config={"encryption-keys-secret-id": _SECRET_ID},
+            relations=[peer],
+            leader=True,
+        )
+        with charm_ctx(charm_ctx.on.update_status(), state) as mgr:
+            secret = mgr.charm.system_client_secret
+            assert secret != ""  # nosec B105
+            assert mgr.charm.system_client_secret == secret
+
+    def test_non_leader_returns_empty_before_leader_creates(self, charm_ctx):
+        """Non-leader returns empty string when secret has not yet been created."""
+        peer = testing.PeerRelation(endpoint="peer")
+        state = testing.State(
+            config={"encryption-keys-secret-id": _SECRET_ID},
+            relations=[peer],
+            leader=False,
+        )
+        with charm_ctx(charm_ctx.on.update_status(), state) as mgr:
+            assert mgr.charm.system_client_secret == ""  # nosec B105

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -3,7 +3,8 @@
 
 """Unit tests for state validation in charm.py."""
 
-from unittest.mock import patch
+import json
+from unittest.mock import MagicMock, patch
 
 import ops
 import pytest
@@ -180,3 +181,69 @@ class TestSystemClientSecret:
         )
         with charm_ctx(charm_ctx.on.update_status(), state) as mgr:
             assert mgr.charm.system_client_secret == ""  # nosec B105
+
+
+class TestCheckStateTrinoPatterns:
+    """Tests for trino-patterns config validation in _check_state."""
+
+    @staticmethod
+    def _encryption_secret_mock():
+        """Return a mock Juju secret with valid encryption key contents."""
+        mock_secret = MagicMock()
+        mock_secret.get_content.return_value = {"gms-key": "k1", "frontend-key": "k2"}
+        return mock_secret
+
+    @staticmethod
+    def _state_with_patterns(base_state, trino_patterns):
+        """Build a test State that passes all checks before trino-patterns validation."""
+        peer = testing.PeerRelation(
+            endpoint="peer",
+            local_app_data={
+                "database_connection": json.dumps({"host": "db"}),
+                "kafka_connection": json.dumps({"host": "kafka"}),
+                "opensearch_connection": json.dumps({"host": "os"}),
+            },
+        )
+        return testing.State(
+            config={**base_state.config, "trino-patterns": trino_patterns},
+            relations=[peer],
+        )
+
+    def test_check_state_raises_on_invalid_json(self, charm_ctx, base_state):
+        """_check_state raises UnreadyStateError when trino-patterns is not valid JSON."""
+        state = self._state_with_patterns(base_state, "not-json")
+        with charm_ctx(charm_ctx.on.update_status(), state) as mgr:
+            with patch.object(mgr.charm.model, "get_secret", return_value=self._encryption_secret_mock()):
+                with pytest.raises(exceptions.UnreadyStateError) as exc_info:
+                    mgr.charm._check_state()
+
+        assert "trino-patterns" in str(exc_info.value)
+
+    def test_check_state_raises_on_non_dict_json(self, charm_ctx, base_state):
+        """_check_state raises UnreadyStateError when trino-patterns is a JSON array."""
+        state = self._state_with_patterns(base_state, "[1, 2, 3]")
+        with charm_ctx(charm_ctx.on.update_status(), state) as mgr:
+            with patch.object(mgr.charm.model, "get_secret", return_value=self._encryption_secret_mock()):
+                with pytest.raises(exceptions.UnreadyStateError) as exc_info:
+                    mgr.charm._check_state()
+
+        assert "trino-patterns" in str(exc_info.value)
+        assert "JSON object" in str(exc_info.value)
+
+    def test_check_state_passes_with_valid_patterns(self, charm_ctx, base_state):
+        """_check_state does not raise when trino-patterns is a valid JSON object."""
+        valid = json.dumps({"schema-pattern": {"allow": [".*"], "deny": []}})
+        state = self._state_with_patterns(base_state, valid)
+        with charm_ctx(charm_ctx.on.update_status(), state) as mgr:
+            with patch.object(mgr.charm.model, "get_secret", return_value=self._encryption_secret_mock()):
+                mgr.charm._check_state()
+
+    def test_update_status_blocks_on_invalid_patterns(self, charm_ctx, base_state):
+        """_on_update_status sets BlockedStatus when trino-patterns is not valid JSON."""
+        state = self._state_with_patterns(base_state, "{{bad}}")
+        with charm_ctx(charm_ctx.on.update_status(), state) as mgr:
+            with patch.object(mgr.charm.model, "get_secret", return_value=self._encryption_secret_mock()):
+                state_out = mgr.run()
+
+        assert isinstance(state_out.unit_status, testing.BlockedStatus)
+        assert "trino-patterns" in state_out.unit_status.message

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -235,3 +235,115 @@ def test_frontend_compile_environment_includes_system_client():
     assert env is not None
     assert env["DATAHUB_SYSTEM_CLIENT_ID"] == literals.SYSTEM_CLIENT_ID
     assert env["DATAHUB_SYSTEM_CLIENT_SECRET"] == "my-secret"
+
+
+class TestFrontendRunInitialization:
+    """Tests for FrontendService.run_initialization user.props and truststore steps."""
+
+    @staticmethod
+    def _make_context(*, user_props_done=False, truststore_done=False, password="s3cret"):
+        """Build a ServiceContext wired for FrontendService initialization tests."""
+        state = SimpleNamespace(
+            kafka_connection={
+                "bootstrap_server": "k:9092",
+                "username": "u",
+                "password": "p",
+                "initialized": True,
+            },  # nosec B105
+            opensearch_connection={
+                "host": "os",
+                "port": "9200",
+                "username": "u",
+                "password": "p",
+                "tls-ca": "PEM-CERT",
+                "initialized": True,
+            },  # nosec B105
+            ran_upgrade=True,
+            frontend_user_props_initialized=user_props_done,
+            frontend_truststore_initialized=truststore_done,
+        )
+        container = SimpleNamespace(push=lambda *a, **kw: None)
+        unit = SimpleNamespace(get_container=lambda name: container)
+        charm = SimpleNamespace(
+            _state=state,
+            _ensure_password=lambda: password,
+            unit=unit,
+        )
+        return services.ServiceContext(charm=charm)
+
+    def test_pushes_user_props_when_not_done(self):
+        """user.props is pushed and flag is set when not yet initialized."""
+        context = self._make_context(user_props_done=False, truststore_done=True)
+
+        with patch.object(services.FrontendService, "is_ready", return_value=True):
+            result = services.FrontendService.run_initialization(context)
+
+        assert result is True
+        assert context.charm._state.frontend_user_props_initialized is True
+
+    def test_skips_when_already_initialized(self):
+        """Initialization is skipped when both steps are already done."""
+        context = self._make_context(user_props_done=True, truststore_done=True)
+
+        with patch.object(services.FrontendService, "is_ready", return_value=True):
+            result = services.FrontendService.run_initialization(context)
+
+        assert result is False
+
+    def test_returns_false_when_password_unavailable(self):
+        """Returns False without setting flag when password is empty."""
+        context = self._make_context(user_props_done=False, truststore_done=True, password="")  # nosec B106
+
+        with patch.object(services.FrontendService, "is_ready", return_value=True):
+            result = services.FrontendService.run_initialization(context)
+
+        assert result is False
+        assert context.charm._state.frontend_user_props_initialized is False
+
+
+class TestGMSSetWorkloadVersion:
+    """Tests for GMSService._set_workload_version."""
+
+    @staticmethod
+    def _make_context(*, version_set=False):
+        """Build a ServiceContext wired for GMS workload version tests."""
+        state = SimpleNamespace(gms_workload_version_set=version_set)
+        version_holder = SimpleNamespace(value=None)
+        unit = SimpleNamespace(
+            get_container=lambda name: SimpleNamespace(pull=lambda path: "version: '1.4.0.5'"),
+            set_workload_version=lambda v: setattr(version_holder, "value", v),
+        )
+        charm = SimpleNamespace(_state=state, unit=unit)
+        context = services.ServiceContext(charm=charm)
+        return context, version_holder
+
+    def test_sets_version_when_flag_unset(self):
+        """Workload version is set and flag is marked True."""
+        context, holder = self._make_context(version_set=False)
+
+        services.GMSService._set_workload_version(context)
+
+        assert holder.value == "1.4.0.5"
+        assert context.charm._state.gms_workload_version_set is True
+
+    def test_skips_when_flag_already_set(self):
+        """Workload version extraction is skipped when already done."""
+        context, holder = self._make_context(version_set=True)
+
+        services.GMSService._set_workload_version(context)
+
+        assert holder.value is None
+
+    def test_retries_on_failure(self):
+        """Flag stays unset on failure so the operation retries on next call."""
+        state = SimpleNamespace(gms_workload_version_set=False)
+        unit = SimpleNamespace(
+            get_container=lambda name: SimpleNamespace(pull=lambda path: (_ for _ in ()).throw(Exception("not ready"))),
+            set_workload_version=lambda v: None,
+        )
+        charm = SimpleNamespace(_state=state, unit=unit)
+        context = services.ServiceContext(charm=charm)
+
+        services.GMSService._set_workload_version(context)
+
+        assert state.gms_workload_version_set is not True

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -7,6 +7,7 @@ import os
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import literals
 import services
 
 
@@ -47,7 +48,7 @@ def test_actions_compile_environment_includes_proxy_vars():
         charm=SimpleNamespace(
             _state=state,
             config=config,
-            system_client_id="__datahub_system",
+            system_client_id=literals.SYSTEM_CLIENT_ID,
             system_client_secret="my-secret",  # nosec B106
         )
     )
@@ -87,7 +88,7 @@ def test_actions_compile_environment_omits_proxy_vars_when_unset():
         charm=SimpleNamespace(
             _state=state,
             config=config,
-            system_client_id="__datahub_system",
+            system_client_id=literals.SYSTEM_CLIENT_ID,
             system_client_secret="my-secret",  # nosec B106
         )
     )
@@ -146,7 +147,7 @@ def test_gms_compile_environment_includes_system_client():
         _state=state,
         config=config,
         model=model,
-        system_client_id="__datahub_system",
+        system_client_id=literals.SYSTEM_CLIENT_ID,
         system_client_secret="my-secret",  # nosec B106
     )
     context = services.ServiceContext(charm=charm)
@@ -155,7 +156,7 @@ def test_gms_compile_environment_includes_system_client():
         env = services.GMSService.compile_environment(context)
 
     assert env is not None
-    assert env["DATAHUB_SYSTEM_CLIENT_ID"] == "__datahub_system"
+    assert env["DATAHUB_SYSTEM_CLIENT_ID"] == literals.SYSTEM_CLIENT_ID
     assert env["DATAHUB_SYSTEM_CLIENT_SECRET"] == "my-secret"
 
 
@@ -172,7 +173,7 @@ def test_actions_compile_environment_includes_system_client():
     charm = SimpleNamespace(
         _state=state,
         config=config,
-        system_client_id="__datahub_system",
+        system_client_id=literals.SYSTEM_CLIENT_ID,
         system_client_secret="my-secret",  # nosec B106
     )
     context = services.ServiceContext(charm=charm)
@@ -182,7 +183,7 @@ def test_actions_compile_environment_includes_system_client():
             env = services.ActionsService.compile_environment(context)
 
     assert env is not None
-    assert env["DATAHUB_SYSTEM_CLIENT_ID"] == "__datahub_system"
+    assert env["DATAHUB_SYSTEM_CLIENT_ID"] == literals.SYSTEM_CLIENT_ID
     assert env["DATAHUB_SYSTEM_CLIENT_SECRET"] == "my-secret"
 
 
@@ -222,7 +223,7 @@ def test_frontend_compile_environment_includes_system_client():
         _state=state,
         config=config,
         model=model,
-        system_client_id="__datahub_system",
+        system_client_id=literals.SYSTEM_CLIENT_ID,
         system_client_secret="my-secret",  # nosec B106
     )
     context = services.ServiceContext(charm=charm)
@@ -232,5 +233,5 @@ def test_frontend_compile_environment_includes_system_client():
             env = services.FrontendService.compile_environment(context)
 
     assert env is not None
-    assert env["DATAHUB_SYSTEM_CLIENT_ID"] == "__datahub_system"
+    assert env["DATAHUB_SYSTEM_CLIENT_ID"] == literals.SYSTEM_CLIENT_ID
     assert env["DATAHUB_SYSTEM_CLIENT_SECRET"] == "my-secret"

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -43,7 +43,14 @@ def test_actions_compile_environment_includes_proxy_vars():
         }
     )
     config = SimpleNamespace(kafka_topic_prefix="")
-    context = services.ServiceContext(charm=SimpleNamespace(_state=state, config=config))
+    context = services.ServiceContext(
+        charm=SimpleNamespace(
+            _state=state,
+            config=config,
+            system_client_id="__datahub_system",
+            system_client_secret="my-secret",  # nosec B106
+        )
+    )
 
     with patch.object(services.ActionsService, "is_enabled", return_value=True):
         with patch.dict(
@@ -76,7 +83,14 @@ def test_actions_compile_environment_omits_proxy_vars_when_unset():
         }
     )
     config = SimpleNamespace(kafka_topic_prefix="")
-    context = services.ServiceContext(charm=SimpleNamespace(_state=state, config=config))
+    context = services.ServiceContext(
+        charm=SimpleNamespace(
+            _state=state,
+            config=config,
+            system_client_id="__datahub_system",
+            system_client_secret="my-secret",  # nosec B106
+        )
+    )
 
     with patch.object(services.ActionsService, "is_enabled", return_value=True):
         with patch.dict(os.environ, {}, clear=True):
@@ -139,6 +153,83 @@ def test_gms_compile_environment_includes_system_client():
 
     with patch.object(services.GMSService, "is_enabled", return_value=True):
         env = services.GMSService.compile_environment(context)
+
+    assert env is not None
+    assert env["DATAHUB_SYSTEM_CLIENT_ID"] == "__datahub_system"
+    assert env["DATAHUB_SYSTEM_CLIENT_SECRET"] == "my-secret"
+
+
+def test_actions_compile_environment_includes_system_client():
+    """Actions environment should include DATAHUB_SYSTEM_CLIENT_ID/SECRET."""
+    state = SimpleNamespace(
+        kafka_connection={
+            "bootstrap_server": "kafka:9092",
+            "username": "user",
+            "password": "pass",  # nosec
+        }
+    )
+    config = SimpleNamespace(kafka_topic_prefix="")
+    charm = SimpleNamespace(
+        _state=state,
+        config=config,
+        system_client_id="__datahub_system",
+        system_client_secret="my-secret",  # nosec B106
+    )
+    context = services.ServiceContext(charm=charm)
+
+    with patch.object(services.ActionsService, "is_enabled", return_value=True):
+        with patch.dict(os.environ, {}, clear=True):
+            env = services.ActionsService.compile_environment(context)
+
+    assert env is not None
+    assert env["DATAHUB_SYSTEM_CLIENT_ID"] == "__datahub_system"
+    assert env["DATAHUB_SYSTEM_CLIENT_SECRET"] == "my-secret"
+
+
+def test_frontend_compile_environment_includes_system_client():
+    """Frontend environment should include DATAHUB_SYSTEM_CLIENT_ID/SECRET."""
+    state = SimpleNamespace(
+        kafka_connection={
+            "bootstrap_server": "kafka:9092",
+            "username": "u",
+            "password": "p",  # nosec
+            "initialized": True,
+        },
+        opensearch_connection={
+            "host": "os",
+            "port": "9200",
+            "username": "u",
+            "password": "p",  # nosec
+            "tls-ca": "cert",
+            "initialized": True,
+        },
+        ran_upgrade=True,
+        frontend_truststore_initialized=True,
+    )
+    encryption_secret = SimpleNamespace(
+        get_content=lambda refresh=False: {"gms-key": "secret123", "frontend-key": "secret456"},
+    )
+    model = SimpleNamespace(get_secret=lambda id: encryption_secret)
+    config = SimpleNamespace(
+        encryption_keys_secret_id="enc-id",  # nosec B106
+        opensearch_index_prefix="",
+        kafka_topic_prefix="",
+        use_play_cache_session_store=False,
+        oidc_secret_id=None,
+        external_fe_hostname="",
+    )
+    charm = SimpleNamespace(
+        _state=state,
+        config=config,
+        model=model,
+        system_client_id="__datahub_system",
+        system_client_secret="my-secret",  # nosec B106
+    )
+    context = services.ServiceContext(charm=charm)
+
+    with patch.object(services.FrontendService, "is_enabled", return_value=True):
+        with patch.dict(os.environ, {}, clear=True):
+            env = services.FrontendService.compile_environment(context)
 
     assert env is not None
     assert env["DATAHUB_SYSTEM_CLIENT_ID"] == "__datahub_system"

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -89,3 +89,57 @@ def test_actions_compile_environment_omits_proxy_vars_when_unset():
     assert "http_proxy" not in env
     assert "https_proxy" not in env
     assert "no_proxy" not in env
+
+
+def test_gms_compile_environment_includes_system_client():
+    """GMS environment should include DATAHUB_SYSTEM_CLIENT_ID/SECRET from trino_relation."""
+    state = SimpleNamespace(
+        database_connection={
+            "host": "db",
+            "port": "5432",
+            "username": "u",
+            "password": "p",  # nosec
+            "dbname": "datahub_db",
+            "initialized": True,
+        },
+        kafka_connection={
+            "bootstrap_server": "kafka:9092",
+            "username": "u",
+            "password": "p",  # nosec
+            "initialized": True,
+        },
+        opensearch_connection={
+            "host": "os",
+            "port": "9200",
+            "username": "u",
+            "password": "p",  # nosec
+            "tls-ca": "cert",
+            "initialized": True,
+        },
+        ran_upgrade=True,
+        gms_truststore_initialized=True,
+    )
+    encryption_secret = SimpleNamespace(
+        get_content=lambda refresh=False: {"gms-key": "secret123", "frontend-key": "secret456"},
+    )
+    model = SimpleNamespace(get_secret=lambda id: encryption_secret)
+    config = SimpleNamespace(
+        encryption_keys_secret_id="enc-id",  # nosec B106
+        opensearch_index_prefix="",
+        kafka_topic_prefix="",
+    )
+    charm = SimpleNamespace(
+        _state=state,
+        config=config,
+        model=model,
+        system_client_id="__datahub_system",
+        system_client_secret="my-secret",  # nosec B106
+    )
+    context = services.ServiceContext(charm=charm)
+
+    with patch.object(services.GMSService, "is_enabled", return_value=True):
+        env = services.GMSService.compile_environment(context)
+
+    assert env is not None
+    assert env["DATAHUB_SYSTEM_CLIENT_ID"] == "__datahub_system"
+    assert env["DATAHUB_SYSTEM_CLIENT_SECRET"] == "my-secret"

--- a/tests/unit/test_trino.py
+++ b/tests/unit/test_trino.py
@@ -8,11 +8,11 @@ import os
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+from graphql import AuthenticationError
 from relations.trino import (
     GMS_TOKEN_SECRET_NAME,
     JUJU_MANAGED_KEY,
     TrinoRelation,
-    _AuthenticationError,
     _build_ingestion_name,
     _build_managed_extra_args,
     _build_recipe,
@@ -192,7 +192,7 @@ class TestTrinoRelationAuth:
         with (
             patch.object(rel, "_get_stored_access_token", return_value=None),
             patch.object(rel, "_store_access_token") as mock_store,
-            patch("relations.trino._create_access_token", return_value="tok-abc") as mock_create,
+            patch("graphql.create_access_token", return_value="tok-abc") as mock_create,
         ):
             first = rel.access_token
             second = rel.access_token
@@ -206,7 +206,7 @@ class TestTrinoRelationAuth:
         rel = self._make_auth_relation()
         with (
             patch.object(rel, "_get_stored_access_token", return_value="stored-tok"),
-            patch("relations.trino._create_access_token") as mock_create,
+            patch("graphql.create_access_token") as mock_create,
         ):
             assert rel.access_token == "stored-tok"  # nosec B105
             mock_create.assert_not_called()
@@ -298,12 +298,12 @@ class TestReconciliation:  # pylint: disable=too-many-positional-arguments
             rel._access_token = "test-token"  # nosec B105
         return rel
 
-    @patch("relations.trino._delete_ingestion_source")
+    @patch("graphql.delete_ingestion_source")
     @patch("relations.trino._update_ingestion_source")
     @patch("relations.trino._create_ingestion_source")
-    @patch("relations.trino._list_ingestion_sources")
-    @patch("relations.trino._ensure_secret")
-    @patch("relations.trino._list_secrets", return_value={})
+    @patch("graphql.list_ingestion_sources")
+    @patch("graphql.ensure_secret")
+    @patch("graphql.list_secrets", return_value={})
     def test_reconcile_creates_missing(self, _mock_ls, _mock_es, mock_list, mock_create, mock_update, mock_delete):
         """Reconcile creates ingestion for catalogs not yet present."""
         rel = self._make_relation()
@@ -322,12 +322,12 @@ class TestReconciliation:  # pylint: disable=too-many-positional-arguments
         mock_update.assert_not_called()
         mock_delete.assert_not_called()
 
-    @patch("relations.trino._delete_ingestion_source")
+    @patch("graphql.delete_ingestion_source")
     @patch("relations.trino._update_ingestion_source")
     @patch("relations.trino._create_ingestion_source")
-    @patch("relations.trino._list_ingestion_sources")
-    @patch("relations.trino._ensure_secret")
-    @patch("relations.trino._list_secrets", return_value={})
+    @patch("graphql.list_ingestion_sources")
+    @patch("graphql.ensure_secret")
+    @patch("graphql.list_secrets", return_value={})
     def test_reconcile_updates_existing(self, _mock_ls, _mock_es, mock_list, mock_create, mock_update, mock_delete):
         """Reconcile updates ingestion for catalogs already present."""
         rel = self._make_relation()
@@ -353,12 +353,12 @@ class TestReconciliation:  # pylint: disable=too-many-positional-arguments
         mock_update.assert_called_once()
         mock_delete.assert_not_called()
 
-    @patch("relations.trino._delete_ingestion_source")
+    @patch("graphql.delete_ingestion_source")
     @patch("relations.trino._update_ingestion_source")
     @patch("relations.trino._create_ingestion_source")
-    @patch("relations.trino._list_ingestion_sources")
-    @patch("relations.trino._ensure_secret")
-    @patch("relations.trino._list_secrets", return_value={})
+    @patch("graphql.list_ingestion_sources")
+    @patch("graphql.ensure_secret")
+    @patch("graphql.list_secrets", return_value={})
     def test_reconcile_deletes_obsolete(self, _mock_ls, _mock_es, mock_list, mock_create, mock_update, mock_delete):
         """Reconcile deletes ingestion for catalogs no longer in relation."""
         rel = self._make_relation()
@@ -382,12 +382,12 @@ class TestReconciliation:  # pylint: disable=too-many-positional-arguments
         mock_update.assert_not_called()
         mock_delete.assert_called_once_with("test-token", "urn:old")
 
-    @patch("relations.trino._delete_ingestion_source")
+    @patch("graphql.delete_ingestion_source")
     @patch("relations.trino._update_ingestion_source")
     @patch("relations.trino._create_ingestion_source")
-    @patch("relations.trino._list_ingestion_sources")
-    @patch("relations.trino._ensure_secret")
-    @patch("relations.trino._list_secrets", return_value={})
+    @patch("graphql.list_ingestion_sources")
+    @patch("graphql.ensure_secret")
+    @patch("graphql.list_secrets", return_value={})
     def test_reconcile_noop_when_synced(self, _mock_ls, _mock_es, mock_list, mock_create, mock_update, mock_delete):
         """Reconcile makes no changes when state is already in sync (no-op)."""
         rel = self._make_relation()
@@ -400,8 +400,8 @@ class TestReconciliation:  # pylint: disable=too-many-positional-arguments
         mock_update.assert_not_called()
         mock_delete.assert_not_called()
 
-    @patch("relations.trino._delete_ingestion_source")
-    @patch("relations.trino._list_ingestion_sources")
+    @patch("graphql.delete_ingestion_source")
+    @patch("graphql.list_ingestion_sources")
     def test_cleanup_deletes_all_managed(self, mock_list, mock_delete):
         """Cleanup on relation-broken deletes all Juju-managed sources."""
         rel = self._make_relation()
@@ -433,12 +433,12 @@ class TestReconciliation:  # pylint: disable=too-many-positional-arguments
 class TestScheduleStability:  # pylint: disable=too-many-positional-arguments
     """Tests for schedule-once policy."""
 
-    @patch("relations.trino._delete_ingestion_source")
+    @patch("graphql.delete_ingestion_source")
     @patch("relations.trino._update_ingestion_source")
     @patch("relations.trino._create_ingestion_source")
-    @patch("relations.trino._list_ingestion_sources")
-    @patch("relations.trino._ensure_secret")
-    @patch("relations.trino._list_secrets", return_value={})
+    @patch("graphql.list_ingestion_sources")
+    @patch("graphql.ensure_secret")
+    @patch("graphql.list_secrets", return_value={})
     def test_update_preserves_existing_schedule(
         self, _mock_ls, _mock_es, mock_list, mock_create, mock_update, mock_delete
     ):
@@ -478,12 +478,12 @@ class TestAuthRetry:  # pylint: disable=too-many-positional-arguments
         """Create TrinoRelation wired for auth retry tests."""
         return TestReconciliation()._make_relation()
 
-    @patch("relations.trino._delete_ingestion_source")
+    @patch("graphql.delete_ingestion_source")
     @patch("relations.trino._update_ingestion_source")
     @patch("relations.trino._create_ingestion_source")
-    @patch("relations.trino._list_ingestion_sources")
-    @patch("relations.trino._ensure_secret")
-    @patch("relations.trino._list_secrets")
+    @patch("graphql.list_ingestion_sources")
+    @patch("graphql.ensure_secret")
+    @patch("graphql.list_secrets")
     def test_reconcile_retries_on_auth_error(
         self, mock_ls, _mock_es, mock_list, mock_create, _mock_update, _mock_delete
     ):
@@ -495,12 +495,12 @@ class TestAuthRetry:  # pylint: disable=too-many-positional-arguments
             "trino_catalogs": [catalog],
         }
         rel.trino_catalog.get_credentials.return_value = ("user", "pass")
-        mock_ls.side_effect = [_AuthenticationError("expired"), {}]
+        mock_ls.side_effect = [AuthenticationError("expired"), {}]
         mock_list.return_value = []
         mock_create.return_value = "urn:new"
 
         with (
-            patch("relations.trino._create_access_token", return_value="new-tok"),
+            patch("graphql.create_access_token", return_value="new-tok"),
             patch.object(rel, "_store_access_token") as mock_store,
         ):
             rel._reconcile_ingestions()

--- a/tests/unit/test_trino.py
+++ b/tests/unit/test_trino.py
@@ -9,14 +9,18 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from relations.trino import (
+    GMS_TOKEN_SECRET_NAME,
     JUJU_MANAGED_KEY,
     TrinoRelation,
+    _AuthenticationError,
     _build_ingestion_name,
+    _build_managed_extra_args,
     _build_recipe,
-    _compile_proxy_extra_args,
+    _compile_extra_env_vars,
     _extract_catalog_from_name,
     _filter_juju_managed,
     _IngestionParams,
+    _normalize_secret_name,
     _random_daily_schedule,
 )
 
@@ -46,8 +50,8 @@ class TestHelpers:
         assert 0 <= minute <= 59
         assert hour in {22, 23, 0, 1, 2, 3, 4, 5}
 
-    def test_compile_proxy_extra_args_with_proxies(self):
-        """Compile proxy args when Juju proxy vars are set."""
+    def test_compile_extra_env_vars_with_proxies(self):
+        """Compile extra_env_vars when Juju proxy vars are set."""
         with patch.dict(
             os.environ,
             {
@@ -57,19 +61,61 @@ class TestHelpers:
             },
             clear=True,
         ):
-            args = _compile_proxy_extra_args()
-        assert args["HTTP_PROXY"] == "http://proxy:8080"
-        assert args["HTTPS_PROXY"] == "http://proxy:8443"
-        assert args["NO_PROXY"] == "localhost"
+            env = _compile_extra_env_vars()
+        assert env[JUJU_MANAGED_KEY] == "true"
+        assert env["HTTP_PROXY"] == "http://proxy:8080"
+        assert env["http_proxy"] == "http://proxy:8080"
+        assert env["HTTPS_PROXY"] == "http://proxy:8443"
+        assert env["https_proxy"] == "http://proxy:8443"
+        assert env["NO_PROXY"] == "localhost"
+        assert env["no_proxy"] == "localhost"
 
-    def test_compile_proxy_extra_args_without_proxies(self):
-        """Compile proxy args when no Juju proxy vars are set."""
+    def test_compile_extra_env_vars_without_proxies(self):
+        """Compile extra_env_vars when no Juju proxy vars are set."""
         with patch.dict(os.environ, {}, clear=True):
-            args = _compile_proxy_extra_args()
-        assert not args
+            env = _compile_extra_env_vars()
+        assert env == {JUJU_MANAGED_KEY: "true"}
 
-    def test_filter_juju_managed_includes_managed(self):
-        """Filter includes sources with JUJU_MANAGED=True."""
+    def test_build_managed_extra_args_structure(self):
+        """Build managed extra_args produces a single extra_env_vars entry."""
+        with patch.dict(os.environ, {}, clear=True):
+            args = _build_managed_extra_args()
+        assert len(args) == 1
+        assert args[0]["key"] == "extra_env_vars"
+        env = json.loads(args[0]["value"])
+        assert env[JUJU_MANAGED_KEY] == "true"
+
+    def test_normalize_secret_name(self):
+        """Normalize catalog name into a valid DataHub secret name."""
+        assert _normalize_secret_name("my-catalog.test") == "JUJU_MANAGED_TRINO_PASSWORD_MY_CATALOG_TEST"
+
+    def test_filter_juju_managed_extra_env_vars_format(self):
+        """Filter detects the extra_env_vars JSON format."""
+        sources = [
+            {
+                "urn": "urn:1",
+                "name": "[juju] a-ingestion",
+                "config": {
+                    "extraArgs": [
+                        {
+                            "key": "extra_env_vars",
+                            "value": json.dumps({JUJU_MANAGED_KEY: "true"}),
+                        }
+                    ]
+                },
+            },
+            {
+                "urn": "urn:2",
+                "name": "manual-source",
+                "config": {"extraArgs": []},
+            },
+        ]
+        result = _filter_juju_managed(sources)
+        assert len(result) == 1
+        assert result[0]["urn"] == "urn:1"
+
+    def test_filter_juju_managed_legacy_format(self):
+        """Filter includes sources with legacy top-level JUJU_MANAGED=True."""
         sources = [
             {
                 "urn": "urn:1",
@@ -96,15 +142,18 @@ class TestHelpers:
         assert not result
 
     def test_build_recipe_structure(self):
-        """Build recipe produces valid JSON with expected keys."""
+        """Build recipe produces valid JSON with expected keys and secret references."""
+        default_pattern = {"allow": [".*"], "deny": []}
         params = _IngestionParams(
             trino_url="trino:443",
             username="user",
             password="pass",  # nosec
             access_token="tok123",
-            schema_pattern='{"allow":[".*"],"deny":[]}',
-            table_pattern='{"allow":[".*"],"deny":[]}',
-            column_pattern='{"allow":[".*"],"deny":[]}',
+            trino_patterns={
+                "schema-pattern": default_pattern,
+                "table-pattern": default_pattern,
+                "view-pattern": default_pattern,
+            },
         )
         recipe_str = _build_recipe("my_catalog", params)
         recipe = json.loads(recipe_str)
@@ -112,9 +161,13 @@ class TestHelpers:
         assert recipe["source"]["config"]["database"] == "my_catalog"
         assert recipe["source"]["config"]["host_port"] == "trino:443"
         assert recipe["source"]["config"]["username"] == "user"
+        assert recipe["source"]["config"]["view_pattern"] == default_pattern
+        assert "column_pattern" not in recipe["source"]["config"]
         assert recipe["source"]["config"]["stateful_ingestion"]["enabled"] is True
         assert recipe["source"]["config"]["env"] == "PROD"
-        assert recipe["sink"]["config"]["token"] == "tok123"
+        # Credentials use DataHub secret references
+        assert recipe["source"]["config"]["password"] == "${JUJU_MANAGED_TRINO_PASSWORD_MY_CATALOG}"
+        assert recipe["sink"]["config"]["token"] == f"${{{GMS_TOKEN_SECRET_NAME}}}"
 
 
 class TestTrinoRelationAuth:
@@ -198,20 +251,24 @@ class TestTrinoRelationEvents:
         event.defer.assert_called_once()
 
 
-class TestReconciliation:
+class TestReconciliation:  # pylint: disable=too-many-positional-arguments
     """Tests for ingestion source reconciliation logic."""
 
     def _make_relation(self):
         """Create TrinoRelation with mocked charm wired for reconciliation."""
+        default_pattern = {"allow": [".*"], "deny": []}
+        trino_patterns = json.dumps(
+            {
+                "schema-pattern": default_pattern,
+                "table-pattern": default_pattern,
+                "view-pattern": default_pattern,
+            }
+        )
         with patch("relations.trino.TrinoCatalogRequirer"):
             charm = MagicMock()
             charm.unit.is_leader.return_value = True
             charm._state.is_ready.return_value = True
-            charm.config = SimpleNamespace(
-                schema_pattern='{"allow":[".*"],"deny":[]}',
-                table_pattern='{"allow":[".*"],"deny":[]}',
-                column_pattern='{"allow":[".*"],"deny":[]}',
-            )
+            charm.config = SimpleNamespace(trino_patterns=trino_patterns)
             charm.system_client_id = "__datahub_system"
             charm.system_client_secret = "test-secret"  # nosec B105
             charm.framework = MagicMock()
@@ -226,7 +283,9 @@ class TestReconciliation:
     @patch("relations.trino._update_ingestion_source")
     @patch("relations.trino._create_ingestion_source")
     @patch("relations.trino._list_ingestion_sources")
-    def test_reconcile_creates_missing(self, mock_list, mock_create, mock_update, mock_delete):
+    @patch("relations.trino._ensure_secret")
+    @patch("relations.trino._list_secrets", return_value={})
+    def test_reconcile_creates_missing(self, _mock_ls, _mock_es, mock_list, mock_create, mock_update, mock_delete):
         """Reconcile creates ingestion for catalogs not yet present."""
         rel = self._make_relation()
         catalog = SimpleNamespace(name="sales")
@@ -248,7 +307,9 @@ class TestReconciliation:
     @patch("relations.trino._update_ingestion_source")
     @patch("relations.trino._create_ingestion_source")
     @patch("relations.trino._list_ingestion_sources")
-    def test_reconcile_updates_existing(self, mock_list, mock_create, mock_update, mock_delete):
+    @patch("relations.trino._ensure_secret")
+    @patch("relations.trino._list_secrets", return_value={})
+    def test_reconcile_updates_existing(self, _mock_ls, _mock_es, mock_list, mock_create, mock_update, mock_delete):
         """Reconcile updates ingestion for catalogs already present."""
         rel = self._make_relation()
         catalog = SimpleNamespace(name="sales")
@@ -277,7 +338,9 @@ class TestReconciliation:
     @patch("relations.trino._update_ingestion_source")
     @patch("relations.trino._create_ingestion_source")
     @patch("relations.trino._list_ingestion_sources")
-    def test_reconcile_deletes_obsolete(self, mock_list, mock_create, mock_update, mock_delete):
+    @patch("relations.trino._ensure_secret")
+    @patch("relations.trino._list_secrets", return_value={})
+    def test_reconcile_deletes_obsolete(self, _mock_ls, _mock_es, mock_list, mock_create, mock_update, mock_delete):
         """Reconcile deletes ingestion for catalogs no longer in relation."""
         rel = self._make_relation()
         rel.trino_catalog.get_trino_info.return_value = {
@@ -304,7 +367,9 @@ class TestReconciliation:
     @patch("relations.trino._update_ingestion_source")
     @patch("relations.trino._create_ingestion_source")
     @patch("relations.trino._list_ingestion_sources")
-    def test_reconcile_noop_when_synced(self, mock_list, mock_create, mock_update, mock_delete):
+    @patch("relations.trino._ensure_secret")
+    @patch("relations.trino._list_secrets", return_value={})
+    def test_reconcile_noop_when_synced(self, _mock_ls, _mock_es, mock_list, mock_create, mock_update, mock_delete):
         """Reconcile makes no changes when state is already in sync (no-op)."""
         rel = self._make_relation()
         rel.trino_catalog.get_trino_info.return_value = None
@@ -325,7 +390,14 @@ class TestReconciliation:
             {
                 "urn": "urn:a",
                 "name": "[juju] a-ingestion",
-                "config": {"extraArgs": [{"key": JUJU_MANAGED_KEY, "value": "True"}]},
+                "config": {
+                    "extraArgs": [
+                        {
+                            "key": "extra_env_vars",
+                            "value": json.dumps({JUJU_MANAGED_KEY: "true"}),
+                        }
+                    ]
+                },
             },
             {
                 "urn": "urn:b",
@@ -339,14 +411,18 @@ class TestReconciliation:
         mock_delete.assert_called_once_with("test-token", "urn:a")
 
 
-class TestScheduleStability:
+class TestScheduleStability:  # pylint: disable=too-many-positional-arguments
     """Tests for schedule-once policy."""
 
     @patch("relations.trino._delete_ingestion_source")
     @patch("relations.trino._update_ingestion_source")
     @patch("relations.trino._create_ingestion_source")
     @patch("relations.trino._list_ingestion_sources")
-    def test_update_preserves_existing_schedule(self, mock_list, mock_create, mock_update, mock_delete):
+    @patch("relations.trino._ensure_secret")
+    @patch("relations.trino._list_secrets", return_value={})
+    def test_update_preserves_existing_schedule(
+        self, _mock_ls, _mock_es, mock_list, mock_create, mock_update, mock_delete
+    ):
         """Update reconciliation preserves the original schedule."""
         rel = TestReconciliation()._make_relation()
         catalog = SimpleNamespace(name="marketing")
@@ -374,3 +450,38 @@ class TestScheduleStability:
         call_args = mock_update.call_args
         passed_source = call_args[0][2]
         assert passed_source["schedule"] == original_schedule
+
+
+class TestAuthRetry:  # pylint: disable=too-many-positional-arguments
+    """Tests for authentication error handling and token refresh."""
+
+    def _make_relation(self):
+        """Create TrinoRelation wired for auth retry tests."""
+        return TestReconciliation()._make_relation()
+
+    @patch("relations.trino._delete_ingestion_source")
+    @patch("relations.trino._update_ingestion_source")
+    @patch("relations.trino._create_ingestion_source")
+    @patch("relations.trino._list_ingestion_sources")
+    @patch("relations.trino._ensure_secret")
+    @patch("relations.trino._list_secrets")
+    def test_reconcile_retries_on_auth_error(
+        self, mock_ls, _mock_es, mock_list, mock_create, _mock_update, _mock_delete
+    ):
+        """Reconcile clears token and retries once on auth failure."""
+        rel = self._make_relation()
+        catalog = SimpleNamespace(name="sales")
+        rel.trino_catalog.get_trino_info.return_value = {
+            "trino_url": "trino:443",
+            "trino_catalogs": [catalog],
+        }
+        rel.trino_catalog.get_credentials.return_value = ("user", "pass")
+        mock_ls.side_effect = [_AuthenticationError("expired"), {}]
+        mock_list.return_value = []
+        mock_create.return_value = "urn:new"
+
+        with patch("relations.trino._create_access_token", return_value="new-tok"):
+            rel._reconcile_ingestions()
+
+        assert mock_ls.call_count == 2
+        mock_create.assert_called_once()

--- a/tests/unit/test_trino.py
+++ b/tests/unit/test_trino.py
@@ -8,6 +8,7 @@ import os
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import literals
 from graphql import AuthenticationError
 from relations.trino import (
     GMS_TOKEN_SECRET_NAME,
@@ -177,7 +178,7 @@ class TestTrinoRelationAuth:
         """Create TrinoRelation with mocked charm for auth tests."""
         with patch("relations.trino.TrinoCatalogRequirer"):
             charm = MagicMock()
-            charm.system_client_id = "__datahub_system"
+            charm.system_client_id = literals.SYSTEM_CLIENT_ID
             charm.system_client_secret = "test-secret"  # nosec B105
             charm.framework = MagicMock()
             charm.on = MagicMock()
@@ -198,7 +199,7 @@ class TestTrinoRelationAuth:
             second = rel.access_token
             assert first == "tok-abc"
             assert second == "tok-abc"
-            mock_create.assert_called_once_with("__datahub_system", "test-secret")
+            mock_create.assert_called_once_with(literals.SYSTEM_CLIENT_ID, "test-secret")
             mock_store.assert_called_once_with("tok-abc")
 
     def test_access_token_reused_from_store(self):
@@ -288,7 +289,7 @@ class TestReconciliation:  # pylint: disable=too-many-positional-arguments
             charm.unit.is_leader.return_value = True
             charm._state.is_ready.return_value = True
             charm.config = SimpleNamespace(trino_patterns=trino_patterns)
-            charm.system_client_id = "__datahub_system"
+            charm.system_client_id = literals.SYSTEM_CLIENT_ID
             charm.system_client_secret = "test-secret"  # nosec B105
             charm.framework = MagicMock()
             charm.on = MagicMock()

--- a/tests/unit/test_trino.py
+++ b/tests/unit/test_trino.py
@@ -13,6 +13,7 @@ from graphql import AuthenticationError
 from relations.trino import (
     GMS_TOKEN_SECRET_NAME,
     JUJU_MANAGED_KEY,
+    TRINO_PASSWORD_SECRET_PREFIX,
     TrinoRelation,
     _build_ingestion_name,
     _build_managed_extra_args,
@@ -317,13 +318,16 @@ class TestReconciliation:  # pylint: disable=too-many-positional-arguments
             rel._access_token = "test-token"  # nosec B105
         return rel
 
+    @patch("graphql.delete_secret")
     @patch("graphql.delete_ingestion_source")
     @patch("relations.trino._update_ingestion_source")
     @patch("relations.trino._create_ingestion_source")
     @patch("graphql.list_ingestion_sources")
     @patch("graphql.ensure_secret")
     @patch("graphql.list_secrets", return_value={})
-    def test_reconcile_creates_missing(self, _mock_ls, _mock_es, mock_list, mock_create, mock_update, mock_delete):
+    def test_reconcile_creates_missing(
+        self, _mock_ls, _mock_es, mock_list, mock_create, mock_update, mock_delete, mock_delete_secret
+    ):
         """Reconcile creates ingestion for catalogs not yet present."""
         rel = self._make_relation()
         catalog = SimpleNamespace(name="sales")
@@ -340,14 +344,18 @@ class TestReconciliation:  # pylint: disable=too-many-positional-arguments
         mock_create.assert_called_once()
         mock_update.assert_not_called()
         mock_delete.assert_not_called()
+        mock_delete_secret.assert_not_called()
 
+    @patch("graphql.delete_secret")
     @patch("graphql.delete_ingestion_source")
     @patch("relations.trino._update_ingestion_source")
     @patch("relations.trino._create_ingestion_source")
     @patch("graphql.list_ingestion_sources")
     @patch("graphql.ensure_secret")
     @patch("graphql.list_secrets", return_value={})
-    def test_reconcile_updates_existing(self, _mock_ls, _mock_es, mock_list, mock_create, mock_update, mock_delete):
+    def test_reconcile_updates_existing(
+        self, _mock_ls, _mock_es, mock_list, mock_create, mock_update, mock_delete, mock_delete_secret
+    ):
         """Reconcile updates ingestion for catalogs already present."""
         rel = self._make_relation()
         catalog = SimpleNamespace(name="sales")
@@ -371,21 +379,27 @@ class TestReconciliation:  # pylint: disable=too-many-positional-arguments
         mock_create.assert_not_called()
         mock_update.assert_called_once()
         mock_delete.assert_not_called()
+        mock_delete_secret.assert_not_called()
 
+    @patch("graphql.delete_secret")
     @patch("graphql.delete_ingestion_source")
     @patch("relations.trino._update_ingestion_source")
     @patch("relations.trino._create_ingestion_source")
     @patch("graphql.list_ingestion_sources")
     @patch("graphql.ensure_secret")
-    @patch("graphql.list_secrets", return_value={})
-    def test_reconcile_deletes_obsolete(self, _mock_ls, _mock_es, mock_list, mock_create, mock_update, mock_delete):
-        """Reconcile deletes ingestion for catalogs no longer in relation."""
+    @patch("graphql.list_secrets")
+    def test_reconcile_deletes_obsolete(
+        self, mock_ls, _mock_es, mock_list, mock_create, mock_update, mock_delete, mock_delete_secret
+    ):
+        """Reconcile deletes ingestion and secrets for catalogs no longer in relation."""
         rel = self._make_relation()
         rel.trino_catalog.get_trino_info.return_value = {
             "trino_url": "trino:443",
             "trino_catalogs": [],
         }
         rel.trino_catalog.get_credentials.return_value = ("user", "pass")
+        secret_name = f"{TRINO_PASSWORD_SECRET_PREFIX}LEGACY"
+        mock_ls.return_value = {secret_name: "urn:secret:legacy"}
         mock_list.return_value = [
             {
                 "urn": "urn:old",
@@ -400,14 +414,18 @@ class TestReconciliation:  # pylint: disable=too-many-positional-arguments
         mock_create.assert_not_called()
         mock_update.assert_not_called()
         mock_delete.assert_called_once_with("test-token", "urn:old")
+        mock_delete_secret.assert_called_once_with("test-token", "urn:secret:legacy")
 
+    @patch("graphql.delete_secret")
     @patch("graphql.delete_ingestion_source")
     @patch("relations.trino._update_ingestion_source")
     @patch("relations.trino._create_ingestion_source")
     @patch("graphql.list_ingestion_sources")
     @patch("graphql.ensure_secret")
     @patch("graphql.list_secrets", return_value={})
-    def test_reconcile_noop_when_synced(self, _mock_ls, _mock_es, mock_list, mock_create, mock_update, mock_delete):
+    def test_reconcile_noop_when_synced(
+        self, _mock_ls, _mock_es, mock_list, mock_create, mock_update, mock_delete, mock_delete_secret
+    ):
         """Reconcile makes no changes when state is already in sync (no-op)."""
         rel = self._make_relation()
         rel.trino_catalog.get_trino_info.return_value = None
@@ -418,11 +436,14 @@ class TestReconciliation:  # pylint: disable=too-many-positional-arguments
         mock_create.assert_not_called()
         mock_update.assert_not_called()
         mock_delete.assert_not_called()
+        mock_delete_secret.assert_not_called()
 
+    @patch("graphql.delete_secret")
     @patch("graphql.delete_ingestion_source")
+    @patch("graphql.list_secrets")
     @patch("graphql.list_ingestion_sources")
-    def test_cleanup_deletes_all_managed(self, mock_list, mock_delete):
-        """Cleanup on relation-broken deletes all Juju-managed sources."""
+    def test_cleanup_deletes_all_managed(self, mock_list, mock_list_secrets, mock_delete, mock_delete_secret):
+        """Cleanup on relation-broken deletes all Juju-managed sources and secrets."""
         rel = self._make_relation()
         mock_list.return_value = [
             {
@@ -443,15 +464,24 @@ class TestReconciliation:  # pylint: disable=too-many-positional-arguments
                 "config": {"extraArgs": []},
             },
         ]
+        mock_list_secrets.return_value = {
+            f"{TRINO_PASSWORD_SECRET_PREFIX}A": "urn:secret:a",
+            GMS_TOKEN_SECRET_NAME: "urn:secret:token",
+            "USER_CREATED_SECRET": "urn:secret:user",
+        }  # nosec B105
 
         rel._cleanup_managed_ingestions()
 
         mock_delete.assert_called_once_with("test-token", "urn:a")
+        assert mock_delete_secret.call_count == 2
+        mock_delete_secret.assert_any_call("test-token", "urn:secret:a")
+        mock_delete_secret.assert_any_call("test-token", "urn:secret:token")
 
 
 class TestScheduleStability:  # pylint: disable=too-many-positional-arguments
     """Tests for schedule-once policy."""
 
+    @patch("graphql.delete_secret")
     @patch("graphql.delete_ingestion_source")
     @patch("relations.trino._update_ingestion_source")
     @patch("relations.trino._create_ingestion_source")
@@ -459,7 +489,7 @@ class TestScheduleStability:  # pylint: disable=too-many-positional-arguments
     @patch("graphql.ensure_secret")
     @patch("graphql.list_secrets", return_value={})
     def test_update_preserves_existing_schedule(
-        self, _mock_ls, _mock_es, mock_list, mock_create, mock_update, mock_delete
+        self, _mock_ls, _mock_es, mock_list, mock_create, mock_update, mock_delete, _mock_delete_secret
     ):
         """Update reconciliation preserves the original schedule."""
         rel = TestReconciliation()._make_relation()
@@ -497,6 +527,7 @@ class TestAuthRetry:  # pylint: disable=too-many-positional-arguments
         """Create TrinoRelation wired for auth retry tests."""
         return TestReconciliation()._make_relation()
 
+    @patch("graphql.delete_secret")
     @patch("graphql.delete_ingestion_source")
     @patch("relations.trino._update_ingestion_source")
     @patch("relations.trino._create_ingestion_source")
@@ -504,7 +535,7 @@ class TestAuthRetry:  # pylint: disable=too-many-positional-arguments
     @patch("graphql.ensure_secret")
     @patch("graphql.list_secrets")
     def test_reconcile_retries_on_auth_error(
-        self, mock_ls, _mock_es, mock_list, mock_create, _mock_update, _mock_delete
+        self, mock_ls, _mock_es, mock_list, mock_create, _mock_update, _mock_delete, _mock_delete_secret
     ):
         """Reconcile creates a fresh token, persists it, and retries on auth failure."""
         rel = self._make_relation()

--- a/tests/unit/test_trino.py
+++ b/tests/unit/test_trino.py
@@ -115,24 +115,6 @@ class TestHelpers:
         assert len(result) == 1
         assert result[0]["urn"] == "urn:1"
 
-    def test_filter_juju_managed_legacy_format(self):
-        """Filter includes sources with legacy top-level JUJU_MANAGED=True."""
-        sources = [
-            {
-                "urn": "urn:1",
-                "name": "[juju] a-ingestion",
-                "config": {"extraArgs": [{"key": JUJU_MANAGED_KEY, "value": "True"}]},
-            },
-            {
-                "urn": "urn:2",
-                "name": "manual-source",
-                "config": {"extraArgs": []},
-            },
-        ]
-        result = _filter_juju_managed(sources)
-        assert len(result) == 1
-        assert result[0]["urn"] == "urn:1"
-
     def test_filter_juju_managed_empty_extra_args(self):
         """Filter handles sources with no extraArgs gracefully."""
         sources = [
@@ -317,7 +299,7 @@ class TestReconciliation:  # pylint: disable=too-many-positional-arguments
         mock_list.return_value = []
         mock_create.return_value = "urn:new"
 
-        rel._reconcile_ingestions()
+        rel.reconcile_ingestions()
 
         mock_create.assert_called_once()
         mock_update.assert_not_called()
@@ -343,12 +325,12 @@ class TestReconciliation:  # pylint: disable=too-many-positional-arguments
                 "urn": "urn:existing",
                 "name": "[juju] sales-ingestion",
                 "type": "trino",
-                "config": {"extraArgs": [{"key": JUJU_MANAGED_KEY, "value": "True"}]},
+                "config": {"extraArgs": [{"key": "extra_env_vars", "value": json.dumps({JUJU_MANAGED_KEY: "true"})}]},
                 "schedule": {"interval": "30 3 * * *", "timezone": "UTC"},
             }
         ]
 
-        rel._reconcile_ingestions()
+        rel.reconcile_ingestions()
 
         mock_create.assert_not_called()
         mock_update.assert_called_once()
@@ -373,11 +355,11 @@ class TestReconciliation:  # pylint: disable=too-many-positional-arguments
                 "urn": "urn:old",
                 "name": "[juju] legacy-ingestion",
                 "type": "trino",
-                "config": {"extraArgs": [{"key": JUJU_MANAGED_KEY, "value": "True"}]},
+                "config": {"extraArgs": [{"key": "extra_env_vars", "value": json.dumps({JUJU_MANAGED_KEY: "true"})}]},
             }
         ]
 
-        rel._reconcile_ingestions()
+        rel.reconcile_ingestions()
 
         mock_create.assert_not_called()
         mock_update.assert_not_called()
@@ -394,7 +376,7 @@ class TestReconciliation:  # pylint: disable=too-many-positional-arguments
         rel = self._make_relation()
         rel.trino_catalog.get_trino_info.return_value = None
 
-        rel._reconcile_ingestions()
+        rel.reconcile_ingestions()
 
         mock_list.assert_not_called()
         mock_create.assert_not_called()
@@ -458,14 +440,14 @@ class TestScheduleStability:  # pylint: disable=too-many-positional-arguments
                 "name": "[juju] marketing-ingestion",
                 "type": "trino",
                 "config": {
-                    "extraArgs": [{"key": JUJU_MANAGED_KEY, "value": "True"}],
-                    "executorId": "default",
+                    "extraArgs": [{"key": "extra_env_vars", "value": json.dumps({JUJU_MANAGED_KEY: "true"})}],
+                    "executorId": literals.DEFAULT_EXECUTOR_ID,
                 },
                 "schedule": original_schedule,
             }
         ]
 
-        rel._reconcile_ingestions()
+        rel.reconcile_ingestions()
 
         call_args = mock_update.call_args
         passed_source = call_args[0][2]
@@ -504,7 +486,7 @@ class TestAuthRetry:  # pylint: disable=too-many-positional-arguments
             patch("graphql.create_access_token", return_value="new-tok"),
             patch.object(rel, "_store_access_token") as mock_store,
         ):
-            rel._reconcile_ingestions()
+            rel.reconcile_ingestions()
 
         assert mock_ls.call_count == 2
         mock_create.assert_called_once()

--- a/tests/unit/test_trino.py
+++ b/tests/unit/test_trino.py
@@ -21,6 +21,7 @@ from relations.trino import (
     _extract_catalog_from_name,
     _filter_juju_managed,
     _IngestionParams,
+    _is_https,
     _normalize_secret_name,
     _random_daily_schedule,
 )
@@ -124,6 +125,19 @@ class TestHelpers:
         result = _filter_juju_managed(sources)
         assert not result
 
+    def test_is_https_port_443(self):
+        """Port 443 is detected as HTTPS."""
+        assert _is_https("trino.example.com:443") is True
+
+    def test_is_https_non_443_port(self):
+        """Non-443 ports are detected as HTTP."""
+        assert _is_https("trino:8080") is False
+        assert _is_https("trino:8443") is False
+
+    def test_is_https_no_port(self):
+        """URL without a port defaults to HTTP."""
+        assert _is_https("trino.example.com") is False
+
     def test_build_recipe_structure(self):
         """Build recipe produces valid JSON with expected keys and secret references."""
         default_pattern = {"allow": [".*"], "deny": []}
@@ -148,9 +162,29 @@ class TestHelpers:
         assert "column_pattern" not in recipe["source"]["config"]
         assert recipe["source"]["config"]["stateful_ingestion"]["enabled"] is True
         assert recipe["source"]["config"]["env"] == "PROD"
-        # Credentials use DataHub secret references
+        # Credentials use DataHub secret references (HTTPS connection)
         assert recipe["source"]["config"]["password"] == "${JUJU_MANAGED_TRINO_PASSWORD_MY_CATALOG}"
         assert recipe["sink"]["config"]["token"] == f"${{{GMS_TOKEN_SECRET_NAME}}}"
+
+    def test_build_recipe_omits_password_for_http(self):
+        """Build recipe omits the password field when the connection is over HTTP."""
+        default_pattern = {"allow": [".*"], "deny": []}
+        params = _IngestionParams(
+            trino_url="trino:8080",
+            username="user",
+            password="pass",  # nosec
+            access_token="tok123",
+            trino_patterns={
+                "schema-pattern": default_pattern,
+                "table-pattern": default_pattern,
+                "view-pattern": default_pattern,
+            },
+        )
+        recipe_str = _build_recipe("my_catalog", params)
+        recipe = json.loads(recipe_str)
+        assert "password" not in recipe["source"]["config"]
+        assert recipe["source"]["config"]["host_port"] == "trino:8080"
+        assert recipe["source"]["config"]["username"] == "user"
 
 
 class TestTrinoRelationAuth:

--- a/tests/unit/test_trino.py
+++ b/tests/unit/test_trino.py
@@ -1,0 +1,374 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Unit tests for src/relations/trino.py."""
+
+import json
+import os
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from relations.trino import (
+    JUJU_MANAGED_KEY,
+    TrinoRelation,
+    _build_ingestion_name,
+    _build_recipe,
+    _compile_proxy_extra_args,
+    _extract_catalog_from_name,
+    _filter_juju_managed,
+    _IngestionParams,
+    _random_daily_schedule,
+)
+
+
+class TestHelpers:
+    """Tests for module-level helper functions."""
+
+    def test_build_ingestion_name(self):
+        """Build canonical name from catalog name."""
+        assert _build_ingestion_name("sales") == "[juju] sales-ingestion"
+
+    def test_extract_catalog_from_name(self):
+        """Extract catalog name from canonical ingestion name."""
+        assert _extract_catalog_from_name("[juju] sales-ingestion") == "sales"
+
+    def test_extract_catalog_from_name_plain(self):
+        """Extract from a name without the prefix/suffix gracefully."""
+        assert _extract_catalog_from_name("sales") == "sales"
+
+    def test_random_daily_schedule_format(self):
+        """Schedule string is a valid 5-field cron within the expected hours."""
+        schedule = _random_daily_schedule()
+        parts = schedule.split()
+        assert len(parts) == 5
+        minute = int(parts[0])
+        hour = int(parts[1])
+        assert 0 <= minute <= 59
+        assert hour in {22, 23, 0, 1, 2, 3, 4, 5}
+
+    def test_compile_proxy_extra_args_with_proxies(self):
+        """Compile proxy args when Juju proxy vars are set."""
+        with patch.dict(
+            os.environ,
+            {
+                "JUJU_CHARM_HTTP_PROXY": "http://proxy:8080",
+                "JUJU_CHARM_HTTPS_PROXY": "http://proxy:8443",
+                "JUJU_CHARM_NO_PROXY": "localhost",
+            },
+            clear=True,
+        ):
+            args = _compile_proxy_extra_args()
+        assert args["HTTP_PROXY"] == "http://proxy:8080"
+        assert args["HTTPS_PROXY"] == "http://proxy:8443"
+        assert args["NO_PROXY"] == "localhost"
+
+    def test_compile_proxy_extra_args_without_proxies(self):
+        """Compile proxy args when no Juju proxy vars are set."""
+        with patch.dict(os.environ, {}, clear=True):
+            args = _compile_proxy_extra_args()
+        assert not args
+
+    def test_filter_juju_managed_includes_managed(self):
+        """Filter includes sources with JUJU_MANAGED=True."""
+        sources = [
+            {
+                "urn": "urn:1",
+                "name": "[juju] a-ingestion",
+                "config": {"extraArgs": [{"key": JUJU_MANAGED_KEY, "value": "True"}]},
+            },
+            {
+                "urn": "urn:2",
+                "name": "manual-source",
+                "config": {"extraArgs": []},
+            },
+        ]
+        result = _filter_juju_managed(sources)
+        assert len(result) == 1
+        assert result[0]["urn"] == "urn:1"
+
+    def test_filter_juju_managed_empty_extra_args(self):
+        """Filter handles sources with no extraArgs gracefully."""
+        sources = [
+            {"urn": "urn:1", "name": "foo", "config": {}},
+            {"urn": "urn:2", "name": "bar", "config": {"extraArgs": None}},
+        ]
+        result = _filter_juju_managed(sources)
+        assert not result
+
+    def test_build_recipe_structure(self):
+        """Build recipe produces valid JSON with expected keys."""
+        params = _IngestionParams(
+            trino_url="trino:443",
+            username="user",
+            password="pass",  # nosec
+            access_token="tok123",
+            schema_pattern='{"allow":[".*"],"deny":[]}',
+            table_pattern='{"allow":[".*"],"deny":[]}',
+            column_pattern='{"allow":[".*"],"deny":[]}',
+        )
+        recipe_str = _build_recipe("my_catalog", params)
+        recipe = json.loads(recipe_str)
+        assert recipe["source"]["type"] == "trino"
+        assert recipe["source"]["config"]["database"] == "my_catalog"
+        assert recipe["source"]["config"]["host_port"] == "trino:443"
+        assert recipe["source"]["config"]["username"] == "user"
+        assert recipe["source"]["config"]["stateful_ingestion"]["enabled"] is True
+        assert recipe["source"]["config"]["env"] == "PROD"
+        assert recipe["sink"]["config"]["token"] == "tok123"
+
+
+class TestTrinoRelationAuth:
+    """Tests for TrinoRelation auth lifecycle properties."""
+
+    def test_access_token_created_lazily(self):
+        """Access token is lazily created via _create_access_token."""
+        with patch("relations.trino.TrinoCatalogRequirer"):
+            charm = MagicMock()
+            charm.system_client_secret = "test-secret"  # nosec B105
+            charm.framework = MagicMock()
+            charm.on = MagicMock()
+            rel = TrinoRelation.__new__(TrinoRelation)
+            rel.charm = charm
+            rel._access_token = None
+
+        with patch("relations.trino._create_access_token", return_value="tok-abc") as mock_create:
+            first = rel.access_token
+            second = rel.access_token
+            assert first == "tok-abc"
+            assert second == "tok-abc"
+            mock_create.assert_called_once_with("test-secret")
+
+
+class TestTrinoRelationEvents:
+    """Tests for TrinoRelation event handlers."""
+
+    def _make_relation(self):
+        """Create TrinoRelation with mocked charm and library."""
+        with patch("relations.trino.TrinoCatalogRequirer"):
+            charm = MagicMock()
+            charm.unit.is_leader.return_value = True
+            charm._state.is_ready.return_value = True
+            charm.framework = MagicMock()
+            charm.on = MagicMock()
+            rel = TrinoRelation.__new__(TrinoRelation)
+            rel.charm = charm
+            rel.trino_catalog = MagicMock()
+            rel._access_token = None
+        return rel
+
+    def test_on_changed_skips_non_leader(self):
+        """Changed event is skipped when unit is not leader."""
+        rel = self._make_relation()
+        rel.charm.unit.is_leader.return_value = False
+        event = MagicMock()
+
+        rel._on_trino_catalog_changed(event)
+
+        rel.charm._update.assert_not_called()
+
+    def test_on_changed_defers_when_state_not_ready(self):
+        """Changed event is deferred when peer relation is not ready."""
+        rel = self._make_relation()
+        rel.charm._state.is_ready.return_value = False
+        event = MagicMock()
+
+        rel._on_trino_catalog_changed(event)
+
+        event.defer.assert_called_once()
+
+    def test_on_broken_skips_non_leader(self):
+        """Broken event is skipped when unit is not leader."""
+        rel = self._make_relation()
+        rel.charm.unit.is_leader.return_value = False
+        event = MagicMock()
+
+        rel._on_relation_broken(event)
+
+        rel.charm._update.assert_not_called()
+
+    def test_on_broken_defers_when_state_not_ready(self):
+        """Broken event is deferred when peer relation is not ready."""
+        rel = self._make_relation()
+        rel.charm._state.is_ready.return_value = False
+        event = MagicMock()
+
+        rel._on_relation_broken(event)
+
+        event.defer.assert_called_once()
+
+
+class TestReconciliation:
+    """Tests for ingestion source reconciliation logic."""
+
+    def _make_relation(self):
+        """Create TrinoRelation with mocked charm wired for reconciliation."""
+        with patch("relations.trino.TrinoCatalogRequirer"):
+            charm = MagicMock()
+            charm.unit.is_leader.return_value = True
+            charm._state.is_ready.return_value = True
+            charm.config = SimpleNamespace(
+                schema_pattern='{"allow":[".*"],"deny":[]}',
+                table_pattern='{"allow":[".*"],"deny":[]}',
+                column_pattern='{"allow":[".*"],"deny":[]}',
+            )
+            charm.system_client_secret = "test-secret"  # nosec B105
+            charm.framework = MagicMock()
+            charm.on = MagicMock()
+            rel = TrinoRelation.__new__(TrinoRelation)
+            rel.charm = charm
+            rel.trino_catalog = MagicMock()
+            rel._access_token = "test-token"  # nosec B105
+        return rel
+
+    @patch("relations.trino._delete_ingestion_source")
+    @patch("relations.trino._update_ingestion_source")
+    @patch("relations.trino._create_ingestion_source")
+    @patch("relations.trino._list_ingestion_sources")
+    def test_reconcile_creates_missing(self, mock_list, mock_create, mock_update, mock_delete):
+        """Reconcile creates ingestion for catalogs not yet present."""
+        rel = self._make_relation()
+        catalog = SimpleNamespace(name="sales")
+        rel.trino_catalog.get_trino_info.return_value = {
+            "trino_url": "trino:443",
+            "trino_catalogs": [catalog],
+        }
+        rel.trino_catalog.get_credentials.return_value = ("user", "pass")
+        mock_list.return_value = []
+        mock_create.return_value = "urn:new"
+
+        rel._reconcile_ingestions()
+
+        mock_create.assert_called_once()
+        mock_update.assert_not_called()
+        mock_delete.assert_not_called()
+
+    @patch("relations.trino._delete_ingestion_source")
+    @patch("relations.trino._update_ingestion_source")
+    @patch("relations.trino._create_ingestion_source")
+    @patch("relations.trino._list_ingestion_sources")
+    def test_reconcile_updates_existing(self, mock_list, mock_create, mock_update, mock_delete):
+        """Reconcile updates ingestion for catalogs already present."""
+        rel = self._make_relation()
+        catalog = SimpleNamespace(name="sales")
+        rel.trino_catalog.get_trino_info.return_value = {
+            "trino_url": "trino:443",
+            "trino_catalogs": [catalog],
+        }
+        rel.trino_catalog.get_credentials.return_value = ("user", "pass")
+        mock_list.return_value = [
+            {
+                "urn": "urn:existing",
+                "name": "[juju] sales-ingestion",
+                "type": "trino",
+                "config": {"extraArgs": [{"key": JUJU_MANAGED_KEY, "value": "True"}]},
+                "schedule": {"interval": "30 3 * * *", "timezone": "UTC"},
+            }
+        ]
+
+        rel._reconcile_ingestions()
+
+        mock_create.assert_not_called()
+        mock_update.assert_called_once()
+        mock_delete.assert_not_called()
+
+    @patch("relations.trino._delete_ingestion_source")
+    @patch("relations.trino._update_ingestion_source")
+    @patch("relations.trino._create_ingestion_source")
+    @patch("relations.trino._list_ingestion_sources")
+    def test_reconcile_deletes_obsolete(self, mock_list, mock_create, mock_update, mock_delete):
+        """Reconcile deletes ingestion for catalogs no longer in relation."""
+        rel = self._make_relation()
+        rel.trino_catalog.get_trino_info.return_value = {
+            "trino_url": "trino:443",
+            "trino_catalogs": [],
+        }
+        rel.trino_catalog.get_credentials.return_value = ("user", "pass")
+        mock_list.return_value = [
+            {
+                "urn": "urn:old",
+                "name": "[juju] legacy-ingestion",
+                "type": "trino",
+                "config": {"extraArgs": [{"key": JUJU_MANAGED_KEY, "value": "True"}]},
+            }
+        ]
+
+        rel._reconcile_ingestions()
+
+        mock_create.assert_not_called()
+        mock_update.assert_not_called()
+        mock_delete.assert_called_once_with("test-secret", "urn:old")
+
+    @patch("relations.trino._delete_ingestion_source")
+    @patch("relations.trino._update_ingestion_source")
+    @patch("relations.trino._create_ingestion_source")
+    @patch("relations.trino._list_ingestion_sources")
+    def test_reconcile_noop_when_synced(self, mock_list, mock_create, mock_update, mock_delete):
+        """Reconcile makes no changes when state is already in sync (no-op)."""
+        rel = self._make_relation()
+        rel.trino_catalog.get_trino_info.return_value = None
+
+        rel._reconcile_ingestions()
+
+        mock_list.assert_not_called()
+        mock_create.assert_not_called()
+        mock_update.assert_not_called()
+        mock_delete.assert_not_called()
+
+    @patch("relations.trino._delete_ingestion_source")
+    @patch("relations.trino._list_ingestion_sources")
+    def test_cleanup_deletes_all_managed(self, mock_list, mock_delete):
+        """Cleanup on relation-broken deletes all Juju-managed sources."""
+        rel = self._make_relation()
+        mock_list.return_value = [
+            {
+                "urn": "urn:a",
+                "name": "[juju] a-ingestion",
+                "config": {"extraArgs": [{"key": JUJU_MANAGED_KEY, "value": "True"}]},
+            },
+            {
+                "urn": "urn:b",
+                "name": "manual-source",
+                "config": {"extraArgs": []},
+            },
+        ]
+
+        rel._cleanup_managed_ingestions()
+
+        mock_delete.assert_called_once_with("test-secret", "urn:a")
+
+
+class TestScheduleStability:
+    """Tests for schedule-once policy."""
+
+    @patch("relations.trino._delete_ingestion_source")
+    @patch("relations.trino._update_ingestion_source")
+    @patch("relations.trino._create_ingestion_source")
+    @patch("relations.trino._list_ingestion_sources")
+    def test_update_preserves_existing_schedule(self, mock_list, mock_create, mock_update, mock_delete):
+        """Update reconciliation preserves the original schedule."""
+        rel = TestReconciliation()._make_relation()
+        catalog = SimpleNamespace(name="marketing")
+        rel.trino_catalog.get_trino_info.return_value = {
+            "trino_url": "trino:443",
+            "trino_catalogs": [catalog],
+        }
+        rel.trino_catalog.get_credentials.return_value = ("user", "pass")
+        original_schedule = {"interval": "15 23 * * *", "timezone": "UTC"}
+        mock_list.return_value = [
+            {
+                "urn": "urn:marketing",
+                "name": "[juju] marketing-ingestion",
+                "type": "trino",
+                "config": {
+                    "extraArgs": [{"key": JUJU_MANAGED_KEY, "value": "True"}],
+                    "executorId": "default",
+                },
+                "schedule": original_schedule,
+            }
+        ]
+
+        rel._reconcile_ingestions()
+
+        call_args = mock_update.call_args
+        passed_source = call_args[0][2]
+        assert passed_source["schedule"] == original_schedule

--- a/tests/unit/test_trino.py
+++ b/tests/unit/test_trino.py
@@ -124,6 +124,7 @@ class TestTrinoRelationAuth:
         """Access token is lazily created via _create_access_token."""
         with patch("relations.trino.TrinoCatalogRequirer"):
             charm = MagicMock()
+            charm.system_client_id = "__datahub_system"
             charm.system_client_secret = "test-secret"  # nosec B105
             charm.framework = MagicMock()
             charm.on = MagicMock()
@@ -136,7 +137,7 @@ class TestTrinoRelationAuth:
             second = rel.access_token
             assert first == "tok-abc"
             assert second == "tok-abc"
-            mock_create.assert_called_once_with("test-secret")
+            mock_create.assert_called_once_with("__datahub_system", "test-secret")
 
 
 class TestTrinoRelationEvents:
@@ -211,6 +212,7 @@ class TestReconciliation:
                 table_pattern='{"allow":[".*"],"deny":[]}',
                 column_pattern='{"allow":[".*"],"deny":[]}',
             )
+            charm.system_client_id = "__datahub_system"
             charm.system_client_secret = "test-secret"  # nosec B105
             charm.framework = MagicMock()
             charm.on = MagicMock()
@@ -296,7 +298,7 @@ class TestReconciliation:
 
         mock_create.assert_not_called()
         mock_update.assert_not_called()
-        mock_delete.assert_called_once_with("test-secret", "urn:old")
+        mock_delete.assert_called_once_with("test-token", "urn:old")
 
     @patch("relations.trino._delete_ingestion_source")
     @patch("relations.trino._update_ingestion_source")
@@ -334,7 +336,7 @@ class TestReconciliation:
 
         rel._cleanup_managed_ingestions()
 
-        mock_delete.assert_called_once_with("test-secret", "urn:a")
+        mock_delete.assert_called_once_with("test-token", "urn:a")
 
 
 class TestScheduleStability:

--- a/tests/unit/test_trino.py
+++ b/tests/unit/test_trino.py
@@ -222,15 +222,16 @@ class TestTrinoRelationEvents:
 
         rel.charm._update.assert_not_called()
 
-    def test_on_changed_defers_when_state_not_ready(self):
-        """Changed event is deferred when peer relation is not ready."""
+    def test_on_changed_returns_when_state_not_ready(self):
+        """Changed event returns without action when peer relation is not ready."""
         rel = self._make_relation()
         rel.charm._state.is_ready.return_value = False
         event = MagicMock()
 
         rel._on_trino_catalog_changed(event)
 
-        event.defer.assert_called_once()
+        event.defer.assert_not_called()
+        rel.charm._update.assert_not_called()
 
     def test_on_broken_skips_non_leader(self):
         """Broken event is skipped when unit is not leader."""
@@ -242,15 +243,16 @@ class TestTrinoRelationEvents:
 
         rel.charm._update.assert_not_called()
 
-    def test_on_broken_defers_when_state_not_ready(self):
-        """Broken event is deferred when peer relation is not ready."""
+    def test_on_broken_returns_when_state_not_ready(self):
+        """Broken event returns without action when peer relation is not ready."""
         rel = self._make_relation()
         rel.charm._state.is_ready.return_value = False
         event = MagicMock()
 
         rel._on_relation_broken(event)
 
-        event.defer.assert_called_once()
+        event.defer.assert_not_called()
+        rel.charm._update.assert_not_called()
 
 
 class TestReconciliation:  # pylint: disable=too-many-positional-arguments

--- a/tests/unit/test_trino.py
+++ b/tests/unit/test_trino.py
@@ -173,8 +173,8 @@ class TestHelpers:
 class TestTrinoRelationAuth:
     """Tests for TrinoRelation auth lifecycle properties."""
 
-    def test_access_token_created_lazily(self):
-        """Access token is lazily created via _create_access_token."""
+    def _make_auth_relation(self):
+        """Create TrinoRelation with mocked charm for auth tests."""
         with patch("relations.trino.TrinoCatalogRequirer"):
             charm = MagicMock()
             charm.system_client_id = "__datahub_system"
@@ -184,13 +184,32 @@ class TestTrinoRelationAuth:
             rel = TrinoRelation.__new__(TrinoRelation)
             rel.charm = charm
             rel._access_token = None
+        return rel
 
-        with patch("relations.trino._create_access_token", return_value="tok-abc") as mock_create:
+    def test_access_token_created_when_no_stored(self):
+        """Access token is created and persisted when nothing is stored."""
+        rel = self._make_auth_relation()
+        with (
+            patch.object(rel, "_get_stored_access_token", return_value=None),
+            patch.object(rel, "_store_access_token") as mock_store,
+            patch("relations.trino._create_access_token", return_value="tok-abc") as mock_create,
+        ):
             first = rel.access_token
             second = rel.access_token
             assert first == "tok-abc"
             assert second == "tok-abc"
             mock_create.assert_called_once_with("__datahub_system", "test-secret")
+            mock_store.assert_called_once_with("tok-abc")
+
+    def test_access_token_reused_from_store(self):
+        """Stored token is reused without calling _create_access_token."""
+        rel = self._make_auth_relation()
+        with (
+            patch.object(rel, "_get_stored_access_token", return_value="stored-tok"),
+            patch("relations.trino._create_access_token") as mock_create,
+        ):
+            assert rel.access_token == "stored-tok"  # nosec B105
+            mock_create.assert_not_called()
 
 
 class TestTrinoRelationEvents:
@@ -468,7 +487,7 @@ class TestAuthRetry:  # pylint: disable=too-many-positional-arguments
     def test_reconcile_retries_on_auth_error(
         self, mock_ls, _mock_es, mock_list, mock_create, _mock_update, _mock_delete
     ):
-        """Reconcile clears token and retries once on auth failure."""
+        """Reconcile creates a fresh token, persists it, and retries on auth failure."""
         rel = self._make_relation()
         catalog = SimpleNamespace(name="sales")
         rel.trino_catalog.get_trino_info.return_value = {
@@ -480,8 +499,12 @@ class TestAuthRetry:  # pylint: disable=too-many-positional-arguments
         mock_list.return_value = []
         mock_create.return_value = "urn:new"
 
-        with patch("relations.trino._create_access_token", return_value="new-tok"):
+        with (
+            patch("relations.trino._create_access_token", return_value="new-tok"),
+            patch.object(rel, "_store_access_token") as mock_store,
+        ):
             rel._reconcile_ingestions()
 
         assert mock_ls.call_count == 2
         mock_create.assert_called_once()
+        mock_store.assert_called_once_with("new-tok")


### PR DESCRIPTION
## Description

The Trino relation will be used to manage ingestions for the catalogs fetched from the Trino application.

Changes:
* DataHub charm implements the provider side of the `trino_catalog` interface.
* At each reconciliation, the charm fetches ingestion sources and Trino catalogs. It takes the necessary actions to reconcile the two. It tags the Juju managed ingestions and does not touch most of the ingestion configurations so there is room for manual management alongside the charm management.
* GraphQL actions require a system user, which is supplied by setting two environment variables for a primitive superuser. One of them is a constant ID while the other is a dynamically generated secret that is persisted in a Juju secret.
* Ingestions are run with an access token that is generated by the system user.

Fixes [CSS-20000](https://warthogs.atlassian.net/browse/CSS-20000).

## Engineering checklist
_Check only items that apply_

- [x] Documentation updated
- [x] Covered by unit tests
- [x] Covered by integration tests
- [ ] Independent change*

 _* This is an independent change if it can be merged and released independently without any related service deployments._

## Merging instructions

The preferred way of merging:
- [ ] Merge
- [x] Squash and Merge
- [ ] Rebase and Merge

## Notes for code reviewers

* ~This requires #24 to be merged first. It will be squashed and merged, so there will be some history management for this branch.~
* ~I think I will merge this into #24 and merge #24 into `main`.~
* I tested this locally. It looks functional for the most part. The only missing test is whether the ingestions run successfully as the Trino charm does not allow password authentication over HTTP and I could not get TLS for Trino.


[CSS-20000]: https://warthogs.atlassian.net/browse/CSS-20000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ