### PR TITLE
fix: expose gms version and restart on check fail

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,7 +124,7 @@ When updating the rocks to a newer version of DataHub (e.g. going from `v1.4.0.5
    ```
 2. In each `rockcraft.yaml`, update the `source-commit` field to the new hash.
 3. Update the comment next to `source-commit` to reflect the new tag (e.g. `# v1.4.1`).
-4. Update other references to the version (such as `version` and `summary`) as necessary.
+4. Update the `version` and `summary` fields at the top of each `rockcraft.yaml` to the new version. This is especially important for the GMS rock: its `override-build` runs `git tag v${CRAFT_PROJECT_VERSION}` before Gradle so that Gradle's `git-properties` plugin can resolve the version. Without this tag the `/config` endpoint returns `"version": "null"`. The `${CRAFT_PROJECT_VERSION}` variable is injected by `rockcraft` from the top-level `version:` field.
 
 ## Code quality
 

--- a/datahub_rocks/gms/rockcraft.yaml
+++ b/datahub_rocks/gms/rockcraft.yaml
@@ -19,7 +19,7 @@ services:
     override: merge
     command: "/datahub/datahub-gms/scripts/start.sh"
     on-check-failure:
-      up: ignore
+      up: restart
     environment:
       JMX_VERSION: "0.20.0"
       LD_LIBRARY_PATH: "/lib:/lib64"

--- a/datahub_rocks/gms/rockcraft.yaml
+++ b/datahub_rocks/gms/rockcraft.yaml
@@ -78,6 +78,13 @@ parts:
       # Ensure python points to python3.11
       ln -sf /usr/bin/python3.11 /usr/bin/python
 
+      # source-depth: 1 strips all tags from the shallow clone, causing
+      # Gradle's git-properties plugin to set git.commit.id.describe=null,
+      # which DataHub surfaces as "version": "null" in the /config endpoint.
+      # Recreate the release tag locally before the build so the plugin
+      # resolves it correctly.
+      git tag "v${CRAFT_PROJECT_VERSION}"
+
       # ── Gradle build ────────────────────────────────────────────────
       ./gradlew :metadata-service:war:build :datahub-upgrade:build \
         -x test -x yarnTest -x yarnLint

--- a/src/charm.py
+++ b/src/charm.py
@@ -69,11 +69,7 @@ def get_pebble_layer(service: services.AbstractService, context: services.Servic
         svc_dict["environment"] = env
 
     if service.healthcheck is not None:
-        svc_dict.update(
-            {
-                "on-check-failure": {"up": "ignore"},
-            }
-        )
+        svc_dict.update({"on-check-failure": {"up": "restart"}})
         layer.update(
             {
                 "checks": {
@@ -182,10 +178,8 @@ class DatahubK8SOperatorCharm(TypedCharmBase[CharmConfig]):
         """
         if event.workload.name == services.FrontendService.name:
             self._state.frontend_user_props_initialized = False
-            self._state.frontend_truststore_initialized = False
         if event.workload.name == services.GMSService.name:
             self._state.gms_workload_version_set = False
-            self._state.gms_truststore_initialized = False
 
         self._update(event)
 
@@ -294,7 +288,6 @@ class DatahubK8SOperatorCharm(TypedCharmBase[CharmConfig]):
         is_down = False
         is_invalid = False
         is_not_ready = False
-        down_services: List[str] = []
         for service in SERVICES:
             if service.healthcheck is None:
                 continue
@@ -327,7 +320,6 @@ class DatahubK8SOperatorCharm(TypedCharmBase[CharmConfig]):
             if check.status != CheckStatus.UP:
                 logger.info("up check failed for '%s'", service.name)
                 is_down = True
-                down_services.append(service.name)
                 continue
             logger.debug("service '%s' is up", service.name)
 
@@ -338,12 +330,7 @@ class DatahubK8SOperatorCharm(TypedCharmBase[CharmConfig]):
             logger.info("services not ready, exiting to wait for the next update")
             self.unit.status = ops.MaintenanceStatus("status check: NOT READY")
         elif is_down:
-            logger.info("services down, attempting restart: %s", down_services)
             self.unit.status = ops.MaintenanceStatus("status check: DOWN")
-            for name in down_services:
-                container = self.unit.get_container(name)
-                if container.can_connect():
-                    container.restart(name)
         else:
             self._reconcile_trino_if_ready()
             self.unit.status = ops.ActiveStatus()

--- a/src/charm.py
+++ b/src/charm.py
@@ -330,6 +330,7 @@ class DatahubK8SOperatorCharm(TypedCharmBase[CharmConfig]):
             logger.info("services not ready, exiting to wait for the next update")
             self.unit.status = ops.MaintenanceStatus("status check: NOT READY")
         elif is_down:
+            logger.info("services down, exiting to wait for the next update")
             self.unit.status = ops.MaintenanceStatus("status check: DOWN")
         else:
             self._reconcile_trino_if_ready()

--- a/src/charm.py
+++ b/src/charm.py
@@ -294,6 +294,7 @@ class DatahubK8SOperatorCharm(TypedCharmBase[CharmConfig]):
         is_down = False
         is_invalid = False
         is_not_ready = False
+        down_services: List[str] = []
         for service in SERVICES:
             if service.healthcheck is None:
                 continue
@@ -326,6 +327,7 @@ class DatahubK8SOperatorCharm(TypedCharmBase[CharmConfig]):
             if check.status != CheckStatus.UP:
                 logger.info("up check failed for '%s'", service.name)
                 is_down = True
+                down_services.append(service.name)
                 continue
             logger.debug("service '%s' is up", service.name)
 
@@ -336,8 +338,12 @@ class DatahubK8SOperatorCharm(TypedCharmBase[CharmConfig]):
             logger.info("services not ready, exiting to wait for the next update")
             self.unit.status = ops.MaintenanceStatus("status check: NOT READY")
         elif is_down:
-            logger.info("services down, exiting to wait for the next update")
+            logger.info("services down, attempting restart: %s", down_services)
             self.unit.status = ops.MaintenanceStatus("status check: DOWN")
+            for name in down_services:
+                container = self.unit.get_container(name)
+                if container.can_connect():
+                    container.restart(name)
         else:
             self._reconcile_trino_if_ready()
             self.unit.status = ops.ActiveStatus()

--- a/src/services.py
+++ b/src/services.py
@@ -359,10 +359,7 @@ class FrontendService(AbstractService):
             Whether the service should be enabled.
         """
         is_ready = cls.is_ready(context)
-        checks = (
-            context.charm._state.frontend_user_props_initialized is True,
-            context.charm._state.frontend_truststore_initialized is True,
-        )
+        checks = (context.charm._state.frontend_user_props_initialized is True,)
         return is_ready and all(checks)
 
     @classmethod
@@ -524,10 +521,6 @@ class FrontendService(AbstractService):
             return False
 
         user_props_done = context.charm._state.frontend_user_props_initialized is True
-        truststore_done = context.charm._state.frontend_truststore_initialized is True
-        if user_props_done and truststore_done:
-            logger.debug("datahub-frontend is already initialized, skipping initialization")
-            return False
 
         container = context.charm.unit.get_container(cls.name)
 
@@ -541,19 +534,20 @@ class FrontendService(AbstractService):
             context.charm._state.frontend_user_props_initialized = True
 
         # Step 2: Truststore initialization for Opensearch SSL.
-        if not truststore_done:
-            certificates = context.charm._state.opensearch_connection["tls-ca"]
-            try:
-                _import_certificates_to_truststore(
-                    container,
-                    certificates,
-                    literals.OPENSEARCH_ROOT_CA_CERT_ALIAS,
-                )
-            except Exception as e:
-                logger.info("Failed to initialize truststore for datahub-frontend: '%s'", str(e))
-                raise exceptions.InitializationFailedError("failed to initialize truststores for datahub-frontend")
-            logger.info("Successful truststore initialization for datahub-frontend")
-            context.charm._state.frontend_truststore_initialized = True
+        # Runs unconditionally on every _update. _import_certificates_to_truststore
+        # has per-alias dedup so re-runs are cheap; running every time is what
+        # makes the truststore self-heal after missing cacerts.
+        certificates = context.charm._state.opensearch_connection["tls-ca"]
+        try:
+            _import_certificates_to_truststore(
+                container,
+                certificates,
+                literals.OPENSEARCH_ROOT_CA_CERT_ALIAS,
+            )
+        except Exception as e:
+            logger.info("Failed to initialize truststore for datahub-frontend: '%s'", str(e))
+            raise exceptions.InitializationFailedError("failed to initialize truststores for datahub-frontend")
+        logger.debug("Truststore for datahub-frontend is up to date")
 
         return True
 
@@ -585,10 +579,7 @@ class GMSService(AbstractService):
             Whether the service should be enabled.
         """
         is_ready = cls.is_ready(context)
-        checks = (
-            context.charm._state.ran_upgrade,
-            context.charm._state.gms_truststore_initialized is True,
-        )
+        checks = (context.charm._state.ran_upgrade,)
         return is_ready and all(checks)
 
     @classmethod
@@ -884,11 +875,6 @@ class GMSService(AbstractService):
         Raises:
             InitializationFailedError: If the initialization fails.
         """
-        check_gms_truststore = context.charm._state.gms_truststore_initialized is True
-        if check_gms_truststore:
-            logger.debug("datahub-gms truststore is already initialized, skipping")
-            return
-
         certificates = context.charm._state.opensearch_connection["tls-ca"]
 
         try:
@@ -901,8 +887,7 @@ class GMSService(AbstractService):
             logger.info("Failed truststore initialization for datahub-gms: '%s'", str(e))
             raise exceptions.InitializationFailedError("failed to initialize truststores for datahub-gms")
 
-        logger.info("Successful truststore initialization for datahub-gms")
-        context.charm._state.gms_truststore_initialized = True
+        logger.debug("Truststore for datahub-gms is up to date")
 
     @classmethod
     def _run_upgrade(cls, context: ServiceContext, container) -> None:

--- a/src/services.py
+++ b/src/services.py
@@ -51,13 +51,12 @@ def _import_certificates_to_truststore(container, certificates: str, alias_prefi
 
         utils.push_contents_to_file(container, cert, cert_path, 0o644)
 
-        # Check if alias already exists;
-        # skip import if it does to avoid truststore mutations while running.
+        # Delete before import so a rotated CA is always refreshed.
         try:
-            check_process = container.exec(
+            delete_process = container.exec(
                 [
                     literals.KEYTOOL_BIN_PATH,
-                    "-list",
+                    "-delete",
                     "-cacerts",
                     "-alias",
                     cert_alias,
@@ -65,11 +64,9 @@ def _import_certificates_to_truststore(container, certificates: str, alias_prefi
                     "changeit",
                 ]
             )
-            check_process.wait_output()
-            logger.debug("Certificate alias '%s' already exists in truststore, skipping import", cert_alias)
-            continue
+            delete_process.wait_output()
         except Exception:
-            logger.debug("Certificate alias '%s' not found in truststore, will import", cert_alias)
+            logger.debug("Certificate alias '%s' not in truststore, nothing to delete", cert_alias)
 
         import_process = container.exec(
             [

--- a/src/services.py
+++ b/src/services.py
@@ -549,6 +549,22 @@ class FrontendService(AbstractService):
             raise exceptions.InitializationFailedError("failed to initialize truststores for datahub-frontend")
         logger.debug("Truststore for datahub-frontend is up to date")
 
+        # Step 3: Patch application.conf to serve static assets with immutable cache headers.
+        # Play defaults to max-age=3600, which forces browsers to re-download and cold-parse
+        # the 18MB JS bundle every hour. Assets use content-addressed filenames (hash in name),
+        # so they are safe to cache indefinitely since the hash changes on each upgrade.
+        app_conf_path = "/datahub-frontend/conf/application.conf"
+        cache_directive = 'play.assets.cache."/public" = "public, max-age=31536000, immutable"'
+        try:
+            app_conf = container.pull(app_conf_path).read()
+            if cache_directive not in app_conf:
+                utils.push_contents_to_file(container, app_conf + f"\n{cache_directive}\n", app_conf_path, 0o644)
+                logger.debug("Patched application.conf with immutable asset cache headers")
+            else:
+                logger.debug("application.conf already contains immutable asset cache directive, skipping")
+        except Exception as e:
+            logger.warning("Failed to patch application.conf for asset cache headers: '%s'", str(e))
+
         return True
 
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -175,6 +175,31 @@ def test_deploy_full(full_stack: jubilant.Juju):
         datahub_version and datahub_version != "null"
     ), f"DataHub /config returned invalid version: {datahub_version!r}"
 
+    # Exercise the OpenSearch-backed search path. If the JVM truststore is
+    # missing the OpenSearch CA, this surfaces as PKIX errors in the GraphQL
+    # response.
+    logger.info("Verifying GMS can serve search queries (OpenSearch TLS path)")
+    session = requests.Session()
+    login_response = session.post(url, json={"username": "datahub", "password": admin_pwd}, timeout=10)
+    assert login_response.status_code == 200
+
+    graphql_url = f"{base_url}/api/v2/graphql"
+    query = {"query": ('{ searchAcrossEntities(input: {types: [DATASET], query: "*", count: 1})' " { total } }")}
+    search_response = session.post(graphql_url, json=query, timeout=15)
+    assert (
+        search_response.status_code == 200
+    ), f"GraphQL request returned {search_response.status_code}: {search_response.text[:500]}"
+
+    body = search_response.json()
+    errors = body.get("errors") or []
+    ssl_errors = [e for e in errors if any(token in str(e) for token in ("PKIX", "SSL", "version='unknown'"))]
+    logger.info(
+        "DATAHUB_GMS_SEARCH errors=%d ssl_errors=%d",
+        len(errors),
+        len(ssl_errors),
+    )
+    assert not ssl_errors, f"SSL/trust errors during search: {ssl_errors}"
+
 
 def test_reindex_action(full_stack: jubilant.Juju):
     """Run and verify the reindex action."""

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -161,6 +161,20 @@ def test_deploy_full(full_stack: jubilant.Juju):
     response = requests.post(url, json={"username": "datahub", "password": admin_pwd}, timeout=10)
     assert response.status_code == 200
 
+    logger.info("Verifying GMS workload version is embedded")
+    gms_url = helpers.get_unit_url(full_stack, helpers.APP_NAME, 0, 8080)
+    config_response = requests.get(f"{gms_url}/config", timeout=10)
+    assert config_response.status_code == 200
+    versions = config_response.json().get("versions", {})
+    datahub_info = versions.get("acryldata/datahub", {})
+    datahub_version = datahub_info.get("version")
+    datahub_commit = datahub_info.get("commit")
+
+    logger.info("DATAHUB_GMS_VERSION version=%s commit=%s", datahub_version, datahub_commit)
+    assert (
+        datahub_version and datahub_version != "null"
+    ), f"DataHub /config returned invalid version: {datahub_version!r}"
+
 
 def test_reindex_action(full_stack: jubilant.Juju):
     """Run and verify the reindex action."""

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -192,13 +192,17 @@ def test_deploy_full(full_stack: jubilant.Juju):
 
     body = search_response.json()
     errors = body.get("errors") or []
+    search_total = body.get("data", {}).get("searchAcrossEntities", {}).get("total")
     ssl_errors = [e for e in errors if any(token in str(e) for token in ("PKIX", "SSL", "version='unknown'"))]
     logger.info(
-        "DATAHUB_GMS_SEARCH errors=%d ssl_errors=%d",
+        "DATAHUB_GMS_SEARCH errors=%d ssl_errors=%d total_present=%s",
         len(errors),
         len(ssl_errors),
+        search_total is not None,
     )
     assert not ssl_errors, f"SSL/trust errors during search: {ssl_errors}"
+    assert not errors, f"GraphQL search returned errors: {errors}"
+    assert search_total is not None, f"GraphQL search did not return data.searchAcrossEntities.total: {body}"
 
 
 def test_reindex_action(full_stack: jubilant.Juju):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -9,11 +9,10 @@ from unittest.mock import MagicMock, patch
 import ops
 import pytest
 from ops import testing
-from ops.pebble import CheckStatus
 
 import exceptions
 import services as svc
-from charm import DatahubK8SOperatorCharm
+from charm import DatahubK8SOperatorCharm, get_pebble_layer
 
 
 class TestGetPasswordAction:
@@ -251,29 +250,21 @@ class TestCheckStateTrinoPatterns:
         assert "trino-patterns" in state_out.unit_status.message
 
 
-class TestUpdateStatusRestart:
-    """Tests for charm-driven container restart on health-check failure."""
+class TestGetPebbleLayer:
+    """Tests for the get_pebble_layer helper."""
 
-    def test_restarts_gms_when_up_check_is_down(self, charm_ctx, base_state):
-        """_on_update_status restarts GMS when its up check reports DOWN."""
-        mock_check = MagicMock()
-        mock_check.status = CheckStatus.DOWN
+    def test_services_with_healthcheck_use_pebble_restart(self):
+        """Services that define a healthcheck must use on-check-failure: restart.
 
-        mock_container = MagicMock()
-        mock_container.can_connect.return_value = True
-        mock_container.get_check.return_value = mock_check
-        # Plan comparison must match to avoid the is_invalid branch.
-        mock_container.get_plan.return_value.to_dict.return_value = {}
+        This ensures pebble can recover a live-but-stuck GMS or frontend.
+        """
+        context = MagicMock()
+        for service in [svc.GMSService, svc.FrontendService]:
+            with patch.object(service, "is_enabled", return_value=True):
+                with patch.object(service, "compile_environment", return_value=None):
+                    layer = get_pebble_layer(service, context)
 
-        with charm_ctx(charm_ctx.on.update_status(), base_state) as mgr:
-            with patch.object(mgr.charm, "_check_state"):
-                with patch("charm.get_pebble_layer", return_value={}):
-                    with patch.object(svc.GMSService, "is_enabled", return_value=True):
-                        # Exclude FrontendService from the loop so is_not_ready stays False.
-                        with patch.object(svc.FrontendService, "healthcheck", new=None):
-                            with patch.object(mgr.charm.unit, "get_container", return_value=mock_container):
-                                state_out = mgr.run()
-
-        mock_container.restart.assert_called_once_with(svc.GMSService.name)
-        assert isinstance(state_out.unit_status, testing.MaintenanceStatus)
-        assert "DOWN" in state_out.unit_status.message
+            on_check_failure = layer["services"][service.name].get("on-check-failure")
+            assert (
+                on_check_failure.get("up") == "restart"
+            ), f"{service.name}: expected on-check-failure up=restart, got {on_check_failure!r}"

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -9,8 +9,10 @@ from unittest.mock import MagicMock, patch
 import ops
 import pytest
 from ops import testing
+from ops.pebble import CheckStatus
 
 import exceptions
+import services as svc
 from charm import DatahubK8SOperatorCharm
 
 
@@ -247,3 +249,31 @@ class TestCheckStateTrinoPatterns:
 
         assert isinstance(state_out.unit_status, testing.BlockedStatus)
         assert "trino-patterns" in state_out.unit_status.message
+
+
+class TestUpdateStatusRestart:
+    """Tests for charm-driven container restart on health-check failure."""
+
+    def test_restarts_gms_when_up_check_is_down(self, charm_ctx, base_state):
+        """_on_update_status restarts GMS when its up check reports DOWN."""
+        mock_check = MagicMock()
+        mock_check.status = CheckStatus.DOWN
+
+        mock_container = MagicMock()
+        mock_container.can_connect.return_value = True
+        mock_container.get_check.return_value = mock_check
+        # Plan comparison must match to avoid the is_invalid branch.
+        mock_container.get_plan.return_value.to_dict.return_value = {}
+
+        with charm_ctx(charm_ctx.on.update_status(), base_state) as mgr:
+            with patch.object(mgr.charm, "_check_state"):
+                with patch("charm.get_pebble_layer", return_value={}):
+                    with patch.object(svc.GMSService, "is_enabled", return_value=True):
+                        # Exclude FrontendService from the loop so is_not_ready stays False.
+                        with patch.object(svc.FrontendService, "healthcheck", new=None):
+                            with patch.object(mgr.charm.unit, "get_container", return_value=mock_container):
+                                state_out = mgr.run()
+
+        mock_container.restart.assert_called_once_with(svc.GMSService.name)
+        assert isinstance(state_out.unit_status, testing.MaintenanceStatus)
+        assert "DOWN" in state_out.unit_status.message

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -132,7 +132,6 @@ def test_gms_compile_environment_includes_system_client():
             "initialized": True,
         },
         ran_upgrade=True,
-        gms_truststore_initialized=True,
     )
     encryption_secret = SimpleNamespace(
         get_content=lambda refresh=False: {"gms-key": "secret123", "frontend-key": "secret456"},
@@ -205,7 +204,6 @@ def test_frontend_compile_environment_includes_system_client():
             "initialized": True,
         },
         ran_upgrade=True,
-        frontend_truststore_initialized=True,
     )
     encryption_secret = SimpleNamespace(
         get_content=lambda refresh=False: {"gms-key": "secret123", "frontend-key": "secret456"},
@@ -241,7 +239,7 @@ class TestFrontendRunInitialization:
     """Tests for FrontendService.run_initialization user.props and truststore steps."""
 
     @staticmethod
-    def _make_context(*, user_props_done=False, truststore_done=False, password="s3cret"):
+    def _make_context(*, user_props_done=False, password="s3cret"):
         """Build a ServiceContext wired for FrontendService initialization tests."""
         state = SimpleNamespace(
             kafka_connection={
@@ -260,7 +258,6 @@ class TestFrontendRunInitialization:
             },  # nosec B105
             ran_upgrade=True,
             frontend_user_props_initialized=user_props_done,
-            frontend_truststore_initialized=truststore_done,
         )
         container = SimpleNamespace(push=lambda *a, **kw: None)
         unit = SimpleNamespace(get_container=lambda name: container)
@@ -273,29 +270,36 @@ class TestFrontendRunInitialization:
 
     def test_pushes_user_props_when_not_done(self):
         """user.props is pushed and flag is set when not yet initialized."""
-        context = self._make_context(user_props_done=False, truststore_done=True)
+        context = self._make_context(user_props_done=False)
 
         with patch.object(services.FrontendService, "is_ready", return_value=True):
-            result = services.FrontendService.run_initialization(context)
+            with patch.object(services, "_import_certificates_to_truststore"):
+                result = services.FrontendService.run_initialization(context)
 
         assert result is True
         assert context.charm._state.frontend_user_props_initialized is True
 
-    def test_skips_when_already_initialized(self):
-        """Initialization is skipped when both steps are already done."""
-        context = self._make_context(user_props_done=True, truststore_done=True)
+    def test_truststore_runs_unconditionally(self):
+        """Truststore import runs even when user.props is already initialized.
+
+        Truststore self-heals after missing cacerts. _import_certificates_to_truststore
+        does its own per-alias dedup, so re-runs are cheap.
+        """
+        context = self._make_context(user_props_done=True)
 
         with patch.object(services.FrontendService, "is_ready", return_value=True):
-            result = services.FrontendService.run_initialization(context)
+            with patch.object(services, "_import_certificates_to_truststore") as mock_import:
+                services.FrontendService.run_initialization(context)
 
-        assert result is False
+        mock_import.assert_called_once()
 
     def test_returns_false_when_password_unavailable(self):
         """Returns False without setting flag when password is empty."""
-        context = self._make_context(user_props_done=False, truststore_done=True, password="")  # nosec B106
+        context = self._make_context(user_props_done=False, password="")  # nosec B106
 
         with patch.object(services.FrontendService, "is_ready", return_value=True):
-            result = services.FrontendService.run_initialization(context)
+            with patch.object(services, "_import_certificates_to_truststore"):
+                result = services.FrontendService.run_initialization(context)
 
         assert result is False
         assert context.charm._state.frontend_user_props_initialized is False


### PR DESCRIPTION
This PR: 
- makes the up check restart the service rather than do nothing when intermittent errors occur
- fixes the gms container version to avoid the `/config` endpoint returning:
```
  "versions": {
    "acryldata/datahub": {
      "version": "null",
      "commit": "32b131fa42c03893a329fe8b0075b14cdac7ce0b"
    }
  }
```

- removes `gms_truststore_initialized` from charm state to allow for recovery on certificate errors:
```
26T13:53:53.354Z [datahub-gms] javax.net.ssl.SSLHandshakeException: PKIX path building failed:
 sun.security.provider.certpath.SunCertPathBuilderException: 
 unable to find valid certification path to requested target
```
- overrides Play framework's default 1-hour asset cache TTL by patching `application.conf` to set `Cache-Control: public, max-age=31536000, immutable` on static assets. without this, any user returning after more than an hour must re-download and cold-parse the 18.5MB JS bundle, adding ~10 seconds to the first page load.



