### PR TITLE
feat: terraform module

### DIFF
--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -26,4 +26,4 @@ jobs:
       doc-automation-disabled: true
     secrets: inherit
     permissions:
-      contents: read
+      contents: write

--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -18,4 +18,4 @@ jobs:
       resource-mapping: '{"datahub-actions": "datahub-actions", "datahub-frontend": "datahub-frontend", "datahub-gms": "datahub-gms"}'
     secrets: inherit
     permissions:
-      contents: read
+      contents: write

--- a/.github/workflows/test_terraform_modules.yaml
+++ b/.github/workflows/test_terraform_modules.yaml
@@ -18,4 +18,5 @@ jobs:
     secrets: inherit
     with:
       lxd-controller-with-k8s-cloud: true
+      additional-setup-script: "./tests/setup/pre_run_script.sh"
       terraform-directories: '["terraform/product"]'

--- a/.github/workflows/test_terraform_modules.yaml
+++ b/.github/workflows/test_terraform_modules.yaml
@@ -1,0 +1,21 @@
+name: Terraform modules tests
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'terraform/**'
+
+jobs:
+  terraform-charm-tests:
+    uses: canonical/operator-workflows/.github/workflows/terraform_modules_test.yaml@main
+    secrets: inherit
+    with:
+      k8s-controller: true
+      terraform-directories: '["terraform/charm"]'
+  terraform-product-tests:
+    uses: canonical/operator-workflows/.github/workflows/terraform_modules_test.yaml@main
+    secrets: inherit
+    with:
+      lxd-controller-with-k8s-cloud: true
+      terraform-directories: '["terraform/product"]'

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,10 @@ __pycache__/
 .idea
 .vscode/
 .mypy_cache/
+
+# Terraform
+.terraform/
+.terraform.lock.hcl
+*.tfstate
+*.tfstate.*
+*.tfplan

--- a/README.md
+++ b/README.md
@@ -133,12 +133,7 @@ The repository ships two Terraform modules:
   from your own Terraform solutions.
 - [`terraform/product`](terraform/product) — a **product module** that deploys the full modernized
   stack (PostgreSQL, Kafka + ZooKeeper, OpenSearch, two Traefik ingresses with TLS), creates and
-  grants the encryption-keys and optional OIDC secrets, and wires everything together. It supports
-  both a single-controller (LXD + K8s cloud) deployment and the two-controller split via
-  external offer-URL inputs. See its [README](terraform/product/README.md) for the topology notes.
-
-The Terraform modules have their own release lifecycle, tagged independently of charm revisions as
-`tf-X.Y.Z`.
+  grants the encryption-keys and optional OIDC secrets, and wires everything together.
 
 ### Configuring Model Proxies
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,21 @@ client-secret: <client-secret-value>
 13. Proceed with the relations.
 14. If your deployment is behind an HTTP proxy, configure model proxies as described in [Configuring Model Proxies](#configuring-model-proxies).
 
+### Deploying with Terraform
+
+The repository ships two Terraform modules:
+
+- [`terraform/charm`](terraform/charm) — a **charm module** for `datahub-k8s` alone, to consume
+  from your own Terraform solutions.
+- [`terraform/product`](terraform/product) — a **product module** that deploys the full modernized
+  stack (PostgreSQL, Kafka + ZooKeeper, OpenSearch, two Traefik ingresses with TLS), creates and
+  grants the encryption-keys and optional OIDC secrets, and wires everything together. It supports
+  both a single-controller (LXD + K8s cloud) deployment and the two-controller split via
+  external offer-URL inputs. See its [README](terraform/product/README.md) for the topology notes.
+
+The Terraform modules have their own release lifecycle, tagged independently of charm revisions as
+`tf-X.Y.Z`.
+
 ### Configuring Model Proxies
 
 If your model runs in a restricted network, configure Juju model proxies so DataHub

--- a/src/services.py
+++ b/src/services.py
@@ -619,9 +619,7 @@ class GMSService(AbstractService):
             "BACKFILL_BROWSE_PATHS_V2": "true",
             # TODO (mertalpt): To be implemented with to o11y update.
             "ENABLE_PROMETHEUS": "false",
-            # MCE consumer is deprecated since DataHub 0.9.x+.
-            # All ingestion uses the MCP/MCL path (rest sink), so it is not needed.
-            "MCE_CONSUMER_ENABLED": "false",
+            "MCE_CONSUMER_ENABLED": "true", # still needed for the ingestion scheduler
             "MAE_CONSUMER_ENABLED": "true",
             "PE_CONSUMER_ENABLED": "true",
             "ENTITY_REGISTRY_CONFIG_PATH": "/datahub/datahub-gms/resources/entity-registry.yml",

--- a/terraform/charm/README.md
+++ b/terraform/charm/README.md
@@ -1,0 +1,47 @@
+# DataHub charm Terraform module
+
+This folder contains a base [Terraform][Terraform] module for the `datahub-k8s` charm.
+
+The module uses the [Terraform Juju provider][Terraform Juju provider] to model the charm
+deployment onto any Kubernetes environment managed by Juju. It models the
+`datahub-k8s` application only without its dependencies (PostgreSQL, Kafka, OpenSearch, ingress)
+are wired up by the higher-level [product module](../product).
+
+## Module structure
+
+- **main.tf** - Defines the `datahub-k8s` Juju application.
+- **variables.tf** - Deployment options (model UUID, channel, revision, config, resources, …).
+- **outputs.tf** - The application name and the `requires` integration endpoints.
+- **terraform.tf** - Terraform and provider version constraints.
+
+## Using `datahub-k8s` base module in higher level modules
+
+```text
+module "datahub" {
+  source     = "git::https://github.com/canonical/datahub-k8s-operator//terraform/charm"
+  model_uuid = var.model_uuid
+  # (Customize configuration variables here if needed)
+}
+```
+
+Create integrations, for instance against Traefik:
+
+```text
+resource "juju_integration" "datahub_frontend_ingress" {
+  model_uuid = var.model_uuid
+  application {
+    name     = module.datahub.app_name
+    endpoint = module.datahub.requires.frontend_ingress
+  }
+  application {
+    name     = "traefik-frontend"
+    endpoint = "ingress"
+  }
+}
+```
+
+The complete list of available integrations can be found [in the Integrations tab][datahub-integrations].
+
+[Terraform]: https://www.terraform.io/
+[Terraform Juju provider]: https://registry.terraform.io/providers/juju/juju/latest
+[datahub-integrations]: https://charmhub.io/datahub-k8s/integrations

--- a/terraform/charm/main.tf
+++ b/terraform/charm/main.tf
@@ -12,7 +12,7 @@ resource "juju_application" "datahub_k8s" {
     base     = var.base
   }
 
-  config      = var.config
+  config      = { for k, v in var.config : k => v if v != null }
   constraints = var.constraints
   resources   = var.resources
   units       = var.units

--- a/terraform/charm/main.tf
+++ b/terraform/charm/main.tf
@@ -1,0 +1,19 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+resource "juju_application" "datahub_k8s" {
+  name       = var.app_name
+  model_uuid = var.model_uuid
+
+  charm {
+    name     = "datahub-k8s"
+    channel  = var.channel
+    revision = var.revision
+    base     = var.base
+  }
+
+  config      = var.config
+  constraints = var.constraints
+  resources   = var.resources
+  units       = var.units
+}

--- a/terraform/charm/main.tf
+++ b/terraform/charm/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2026 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 resource "juju_application" "datahub_k8s" {

--- a/terraform/charm/outputs.tf
+++ b/terraform/charm/outputs.tf
@@ -1,4 +1,4 @@
-# Copyright 2026 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 output "app_name" {

--- a/terraform/charm/outputs.tf
+++ b/terraform/charm/outputs.tf
@@ -1,0 +1,19 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+output "app_name" {
+  description = "Name of the deployed application."
+  value       = juju_application.datahub_k8s.name
+}
+
+output "requires" {
+  description = "Map of the charm's `requires` integration endpoints."
+  value = {
+    db               = "db"
+    kafka            = "kafka"
+    opensearch       = "opensearch"
+    frontend_ingress = "frontend-ingress"
+    gms_ingress      = "gms-ingress"
+    trino_catalog    = "trino-catalog"
+  }
+}

--- a/terraform/charm/terraform.tf
+++ b/terraform/charm/terraform.tf
@@ -1,4 +1,4 @@
-# Copyright 2026 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 terraform {

--- a/terraform/charm/terraform.tf
+++ b/terraform/charm/terraform.tf
@@ -2,11 +2,11 @@
 # See LICENSE file for licensing details.
 
 terraform {
-  required_version = "~> 1.12"
+  required_version = "~> 1.14"
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 1.0"
+      version = "~> 2.0"
     }
   }
 }

--- a/terraform/charm/terraform.tf
+++ b/terraform/charm/terraform.tf
@@ -1,0 +1,12 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+terraform {
+  required_version = "~> 1.12"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 1.0"
+    }
+  }
+}

--- a/terraform/charm/tests/main.tftest.hcl
+++ b/terraform/charm/tests/main.tftest.hcl
@@ -1,4 +1,4 @@
-# Copyright 2026 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 run "setup_tests" {

--- a/terraform/charm/tests/main.tftest.hcl
+++ b/terraform/charm/tests/main.tftest.hcl
@@ -1,0 +1,25 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+run "setup_tests" {
+  module {
+    source = "./tests/setup"
+  }
+}
+
+run "basic_deploy" {
+  variables {
+    model_uuid = run.setup_tests.model_uuid
+    channel    = "latest/edge"
+  }
+
+  assert {
+    condition     = output.app_name == "datahub-k8s"
+    error_message = "datahub-k8s app_name did not match expected"
+  }
+
+  assert {
+    condition     = output.requires.frontend_ingress == "frontend-ingress"
+    error_message = "requires.frontend_ingress endpoint did not match expected"
+  }
+}

--- a/terraform/charm/tests/setup/main.tf
+++ b/terraform/charm/tests/setup/main.tf
@@ -1,0 +1,22 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+terraform {
+  required_version = "~> 1.12"
+  required_providers {
+    juju = {
+      version = "~> 1.0"
+      source  = "juju/juju"
+    }
+  }
+}
+
+provider "juju" {}
+
+resource "juju_model" "test_model" {
+  name = "tf-testing-${formatdate("YYYYMMDDhhmmss", timestamp())}"
+}
+
+output "model_uuid" {
+  value = juju_model.test_model.uuid
+}

--- a/terraform/charm/tests/setup/main.tf
+++ b/terraform/charm/tests/setup/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2026 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 terraform {

--- a/terraform/charm/tests/setup/main.tf
+++ b/terraform/charm/tests/setup/main.tf
@@ -16,19 +16,19 @@ provider "juju" {}
 variable "k8s_cloud_name" {
   description = "Name of the Kubernetes cloud registered on the controller."
   type        = string
-  default     = "microk8s"
+  default     = "tfk8s"
 }
 
 variable "k8s_credential_name" {
   description = "Name of the credential for the Kubernetes cloud."
   type        = string
-  default     = "microk8s"
+  default     = "tfk8s"
 }
 
 variable "workload_storage_class" {
   description = "StorageClass to use for workloads in the Kubernetes model."
   type        = string
-  default     = "microk8s-hostpath"
+  default     = "tfk8s-hostpath"
 }
 
 resource "juju_model" "test_model" {

--- a/terraform/charm/tests/setup/main.tf
+++ b/terraform/charm/tests/setup/main.tf
@@ -13,8 +13,35 @@ terraform {
 
 provider "juju" {}
 
+variable "k8s_cloud_name" {
+  description = "Name of the Kubernetes cloud registered on the controller."
+  type        = string
+  default     = "microk8s"
+}
+
+variable "k8s_credential_name" {
+  description = "Name of the credential for the Kubernetes cloud."
+  type        = string
+  default     = "microk8s"
+}
+
+variable "workload_storage_class" {
+  description = "StorageClass to use for workloads in the Kubernetes model."
+  type        = string
+  default     = "microk8s-hostpath"
+}
+
 resource "juju_model" "test_model" {
-  name = "tf-testing-${formatdate("YYYYMMDDhhmmss", timestamp())}"
+  name       = "tf-testing-${formatdate("YYYYMMDDhhmmss", timestamp())}"
+  credential = var.k8s_credential_name
+
+  cloud {
+    name = var.k8s_cloud_name
+  }
+
+  config = {
+    workload-storage = var.workload_storage_class
+  }
 }
 
 output "model_uuid" {

--- a/terraform/charm/tests/setup/main.tf
+++ b/terraform/charm/tests/setup/main.tf
@@ -2,10 +2,10 @@
 # See LICENSE file for licensing details.
 
 terraform {
-  required_version = "~> 1.12"
+  required_version = "~> 1.14"
   required_providers {
     juju = {
-      version = "~> 1.0"
+      version = "~> 2.0"
       source  = "juju/juju"
     }
   }

--- a/terraform/charm/tests/setup/main.tf
+++ b/terraform/charm/tests/setup/main.tf
@@ -25,22 +25,12 @@ variable "k8s_credential_name" {
   default     = "tfk8s"
 }
 
-variable "workload_storage_class" {
-  description = "StorageClass to use for workloads in the Kubernetes model."
-  type        = string
-  default     = "tfk8s-hostpath"
-}
-
 resource "juju_model" "test_model" {
   name       = "tf-testing-${formatdate("YYYYMMDDhhmmss", timestamp())}"
   credential = var.k8s_credential_name
 
   cloud {
     name = var.k8s_cloud_name
-  }
-
-  config = {
-    workload-storage = var.workload_storage_class
   }
 }
 

--- a/terraform/charm/variables.tf
+++ b/terraform/charm/variables.tf
@@ -21,8 +21,14 @@ variable "channel" {
 
 variable "config" {
   description = "Application configuration. Options at https://charmhub.io/datahub-k8s/configurations."
-  type        = map(string)
-  default     = {}
+  type = object({
+    encryption-keys-secret-id    = optional(string)
+    kafka-topic-prefix           = optional(string)
+    opensearch-index-prefix      = optional(string)
+    use-play-cache-session-store = optional(string)
+    trino-patterns               = optional(string)
+  })
+  default = {}
 }
 
 variable "constraints" {

--- a/terraform/charm/variables.tf
+++ b/terraform/charm/variables.tf
@@ -1,0 +1,55 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+variable "app_name" {
+  description = "Name of the application in the Juju model."
+  type        = string
+  default     = "datahub-k8s"
+}
+
+variable "base" {
+  description = "The operating system on which to deploy."
+  type        = string
+  default     = "ubuntu@22.04"
+}
+
+variable "channel" {
+  description = "The channel to use when deploying the charm."
+  type        = string
+  default     = "latest/edge"
+}
+
+variable "config" {
+  description = "Application configuration. Options at https://charmhub.io/datahub-k8s/configurations."
+  type        = map(string)
+  default     = {}
+}
+
+variable "constraints" {
+  description = "Juju constraints to apply for this application."
+  type        = string
+  default     = null
+}
+
+variable "model_uuid" {
+  description = "Reference to the `juju_model` UUID to deploy to."
+  type        = string
+}
+
+variable "resources" {
+  description = "Map of OCI-image resources (datahub-actions, datahub-frontend, datahub-gms) to use instead of the charm's bundled images."
+  type        = map(string)
+  default     = {}
+}
+
+variable "revision" {
+  description = "Revision number of the charm to deploy. Null deploys the latest revision on the channel."
+  type        = number
+  default     = null
+}
+
+variable "units" {
+  description = "Number of units to deploy."
+  type        = number
+  default     = 1
+}

--- a/terraform/charm/variables.tf
+++ b/terraform/charm/variables.tf
@@ -1,4 +1,4 @@
-# Copyright 2026 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 variable "app_name" {

--- a/terraform/product/README.md
+++ b/terraform/product/README.md
@@ -1,0 +1,52 @@
+# DataHub product Terraform module
+
+This folder contains a [Terraform][Terraform] **product module** that deploys a full, modernized
+DataHub solution: the `datahub-k8s` charm (via the [charm module](../charm)), its data platform
+(PostgreSQL, Kafka + ZooKeeper, OpenSearch + self-signed-certificates), two Traefik ingresses
+(frontend + GMS) with TLS, and the Juju secrets DataHub needs.
+
+## Topology
+
+This is a **single-controller** module: one Juju controller with both a machine cloud and a K8s
+cloud (e.g. LXD + Canonical K8s). DataHub is a K8s charm; its data platform (PostgreSQL, Kafka,
+OpenSearch) are **machine** charms, so they live in a separate machine-cloud model and are consumed
+via cross-model offers. Two modes:
+
+- **Deploy the data platform (default):** leave the `*_offer_url` inputs empty. The module deploys
+  the data platform in `machine_model_uuid`, creates cross-model offers, and consumes them from
+  `k8s_model_uuid`. One `terraform apply` brings up the whole stack.
+- **Bring your own data platform:** point `database_offer_url` / `kafka_offer_url` /
+  `opensearch_offer_url` at an existing data platform offered from another model **on the same
+  controller**. The in-module data-platform deploy is then skipped and DataHub just consumes the
+  offers.
+
+> Set the three `*_offer_url` inputs together (all or none, enforced by variable validation).
+
+## Secrets
+
+The module creates and grants the two Juju secrets DataHub reads:
+
+| Secret | Content | Do you supply values? |
+|--------|---------|------------------------|
+| `datahub-encryption-keys` | `gms-key`, `frontend-key` | **No**, random values are generated (override via `encryption_keys` only to match an existing deployment). |
+| `datahub-oidc` (optional) | `client-id`, `client-secret` | **Only for SSO**, pass the `oidc` variable with real OAuth credentials. Omit (`null`) to disable SSO. |
+
+> Generated keys and any OIDC credentials are stored in Terraform state. 
+> Use an encrypted / remote backend in real deployments.
+
+## Notes & caveats
+
+- **Admin password:** not a Terraform output. Retrieve it with
+  `juju run datahub-k8s/0 get-password`. The proxied URL comes from
+  `juju run traefik-frontend/0 show-proxied-endpoints`.
+- **Multi-user controllers:** when the data platform and DataHub models are owned by different
+  users, grant the offers with `juju grant` (a single-admin controller needs no grant).
+
+## Module structure
+
+- **main.tf** - data platform module, DataHub module, secrets, ingress, TLS, integrations, metadata.
+- **variables.tf** - model UUIDs, per-charm configuration objects, offer-URL toggles, secret inputs.
+- **outputs.tf** - `models`, `metadata`, `offers`.
+- **locals.tf** - deploy/offer resolution and DataHub config assembly.
+- **terraform.tf** - Terraform and provider version constraints.
+- **modules/dependencies** - the machine-model data platform (also usable standalone).

--- a/terraform/product/README.md
+++ b/terraform/product/README.md
@@ -44,9 +44,15 @@ The module creates and grants the two Juju secrets DataHub reads:
 
 ## Module structure
 
-- **main.tf** - data platform module, DataHub module, secrets, ingress, TLS, integrations, metadata.
+This product module is composed entirely of **charm modules** and a **component module**.
+
+- **main.tf** - composes the data-platform component, the DataHub charm module, the ingress
+  (traefik) and TLS (self-signed-certificates) charm modules; creates the secrets and all integrations.
 - **variables.tf** - model UUIDs, per-charm configuration objects, offer-URL toggles, secret inputs.
 - **outputs.tf** - `models`, `metadata`, `offers`.
 - **locals.tf** - deploy/offer resolution and DataHub config assembly.
 - **terraform.tf** - Terraform and provider version constraints.
-- **modules/dependencies** - the machine-model data platform (also usable standalone).
+- **modules/{postgresql,kafka,zookeeper,opensearch,self-signed-certificates,traefik-k8s}** - local
+  **charm modules**: swap each `source` to the official upstream charm module once it is published.
+- **modules/dependencies** - the data-platform **component module**: composes the data-platform
+  charm modules above, wires their integrations, and exposes the cross-model offers.

--- a/terraform/product/locals.tf
+++ b/terraform/product/locals.tf
@@ -1,4 +1,4 @@
-# Copyright 2026 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 locals {

--- a/terraform/product/locals.tf
+++ b/terraform/product/locals.tf
@@ -1,0 +1,28 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+locals {
+  module_version = "0.1.0"
+
+  # Deploy the in-module data platform unless external offer URLs are supplied. The variable
+  # validation guarantees the three *_offer_url inputs are all set or all empty, so the database
+  # one is a sufficient signal.
+  deploy_deps = var.database_offer_url == ""
+
+  # Resolve each offer URL: the in-module offer when the data platform is deployed here, otherwise
+  # the externally supplied offer URL.
+  database_offer   = local.deploy_deps ? module.dependencies[0].offers.database : var.database_offer_url
+  kafka_offer      = local.deploy_deps ? module.dependencies[0].offers.kafka_client : var.kafka_offer_url
+  opensearch_offer = local.deploy_deps ? module.dependencies[0].offers.opensearch_client : var.opensearch_offer_url
+
+  # Encryption keys: overrides when provided, else generated random values.
+  gms_key      = var.encryption_keys.gms_key != "" ? var.encryption_keys.gms_key : random_password.gms_key.result
+  frontend_key = var.encryption_keys.frontend_key != "" ? var.encryption_keys.frontend_key : random_password.frontend_key.result
+
+  # DataHub config = user-provided config plus the secret IDs created by this module.
+  datahub_config = merge(
+    var.datahub.config,
+    { "encryption-keys-secret-id" = juju_secret.encryption_keys.secret_id },
+    var.oidc != null ? { "oidc-secret-id" = juju_secret.oidc[0].secret_id } : {},
+  )
+}

--- a/terraform/product/main.tf
+++ b/terraform/product/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2026 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 ### DATA PLATFORM (machine model): deployed in-module unless external offers are supplied

--- a/terraform/product/main.tf
+++ b/terraform/product/main.tf
@@ -1,0 +1,232 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+### DATA PLATFORM (machine model): deployed in-module unless external offers are supplied
+
+module "dependencies" {
+  count  = local.deploy_deps ? 1 : 0
+  source = "./modules/dependencies"
+
+  model_uuid               = var.machine_model_uuid
+  postgresql               = var.postgresql
+  kafka                    = var.kafka
+  zookeeper                = var.zookeeper
+  opensearch               = var.opensearch
+  self_signed_certificates = var.self_signed_certificates
+}
+
+### DATAHUB (K8s model)
+
+module "datahub" {
+  source = "../charm"
+
+  app_name    = var.datahub.app_name
+  model_uuid  = var.k8s_model_uuid
+  channel     = var.datahub.channel
+  revision    = var.datahub.revision
+  base        = var.datahub.base
+  config      = local.datahub_config
+  constraints = var.datahub.constraints
+  resources   = var.datahub.resources
+  units       = var.datahub.units
+}
+
+### SECRETS (created and granted to DataHub)
+
+resource "random_password" "gms_key" {
+  length  = 32
+  special = false
+}
+
+resource "random_password" "frontend_key" {
+  length  = 32
+  special = false
+}
+
+resource "juju_secret" "encryption_keys" {
+  model_uuid = var.k8s_model_uuid
+  name       = "datahub-encryption-keys"
+  info       = "Frontend and GMS encryption keys for DataHub."
+  value = {
+    "gms-key"      = local.gms_key
+    "frontend-key" = local.frontend_key
+  }
+}
+
+resource "juju_secret" "oidc" {
+  count      = var.oidc != null ? 1 : 0
+  model_uuid = var.k8s_model_uuid
+  name       = "datahub-oidc"
+  info       = "OIDC client credentials for DataHub SSO."
+  value = {
+    "client-id"     = var.oidc.client_id
+    "client-secret" = var.oidc.client_secret
+  }
+}
+
+resource "juju_access_secret" "encryption_keys" {
+  model_uuid   = var.k8s_model_uuid
+  applications = [module.datahub.app_name]
+  secret_id    = juju_secret.encryption_keys.secret_id
+}
+
+resource "juju_access_secret" "oidc" {
+  count        = var.oidc != null ? 1 : 0
+  model_uuid   = var.k8s_model_uuid
+  applications = [module.datahub.app_name]
+  secret_id    = juju_secret.oidc[0].secret_id
+}
+
+### INGRESS (K8s model)
+
+resource "juju_application" "traefik_frontend" {
+  name       = var.traefik_frontend.app_name
+  model_uuid = var.k8s_model_uuid
+  trust      = true
+  units      = var.traefik_frontend.units
+  config     = var.traefik_frontend.config
+
+  charm {
+    name     = "traefik-k8s"
+    channel  = var.traefik_frontend.channel
+    revision = var.traefik_frontend.revision
+  }
+}
+
+resource "juju_application" "traefik_gms" {
+  name       = var.traefik_gms.app_name
+  model_uuid = var.k8s_model_uuid
+  trust      = true
+  units      = var.traefik_gms.units
+  config     = var.traefik_gms.config
+
+  charm {
+    name     = "traefik-k8s"
+    channel  = var.traefik_gms.channel
+    revision = var.traefik_gms.revision
+  }
+}
+
+resource "juju_application" "self_signed_certificates" {
+  name       = var.self_signed_certificates.app_name
+  model_uuid = var.k8s_model_uuid
+  units      = var.self_signed_certificates.units
+  config     = var.self_signed_certificates.config
+
+  charm {
+    name     = "self-signed-certificates"
+    channel  = var.self_signed_certificates.channel
+    revision = var.self_signed_certificates.revision
+  }
+}
+
+### INTEGRATIONS: DataHub to the data platform (cross-model, via offers)
+
+resource "juju_integration" "datahub_database" {
+  model_uuid = var.k8s_model_uuid
+
+  application {
+    name     = module.datahub.app_name
+    endpoint = module.datahub.requires.db
+  }
+
+  application {
+    offer_url = local.database_offer
+  }
+}
+
+resource "juju_integration" "datahub_kafka" {
+  model_uuid = var.k8s_model_uuid
+
+  application {
+    name     = module.datahub.app_name
+    endpoint = module.datahub.requires.kafka
+  }
+
+  application {
+    offer_url = local.kafka_offer
+  }
+}
+
+resource "juju_integration" "datahub_opensearch" {
+  model_uuid = var.k8s_model_uuid
+
+  application {
+    name     = module.datahub.app_name
+    endpoint = module.datahub.requires.opensearch
+  }
+
+  application {
+    offer_url = local.opensearch_offer
+  }
+}
+
+### INTEGRATIONS: DataHub to ingress, and ingress to TLS (in-model)
+
+resource "juju_integration" "datahub_frontend_ingress" {
+  model_uuid = var.k8s_model_uuid
+
+  application {
+    name     = module.datahub.app_name
+    endpoint = module.datahub.requires.frontend_ingress
+  }
+
+  application {
+    name     = juju_application.traefik_frontend.name
+    endpoint = "ingress"
+  }
+}
+
+resource "juju_integration" "datahub_gms_ingress" {
+  model_uuid = var.k8s_model_uuid
+
+  application {
+    name     = module.datahub.app_name
+    endpoint = module.datahub.requires.gms_ingress
+  }
+
+  application {
+    name     = juju_application.traefik_gms.name
+    endpoint = "ingress"
+  }
+}
+
+resource "juju_integration" "traefik_frontend_certificates" {
+  model_uuid = var.k8s_model_uuid
+
+  application {
+    name     = juju_application.traefik_frontend.name
+    endpoint = "certificates"
+  }
+
+  application {
+    name     = juju_application.self_signed_certificates.name
+    endpoint = "certificates"
+  }
+}
+
+resource "juju_integration" "traefik_gms_certificates" {
+  model_uuid = var.k8s_model_uuid
+
+  application {
+    name     = juju_application.traefik_gms.name
+    endpoint = "certificates"
+  }
+
+  application {
+    name     = juju_application.self_signed_certificates.name
+    endpoint = "certificates"
+  }
+}
+
+### METADATA
+
+resource "time_static" "deployed_at" {}
+
+resource "time_static" "updated_at" {
+  triggers = {
+    datahub_channel  = var.datahub.channel
+    datahub_revision = tostring(coalesce(var.datahub.revision, 0))
+    datahub_config   = jsonencode(var.datahub.config)
+  }
+}

--- a/terraform/product/main.tf
+++ b/terraform/product/main.tf
@@ -77,47 +77,43 @@ resource "juju_access_secret" "oidc" {
   secret_id    = juju_secret.oidc[0].secret_id
 }
 
-### INGRESS (K8s model)
+### INGRESS + TLS (K8s model)
 
-resource "juju_application" "traefik_frontend" {
-  name       = var.traefik_frontend.app_name
+module "traefik_frontend" {
+  source = "./modules/traefik-k8s"
+
   model_uuid = var.k8s_model_uuid
-  trust      = true
-  units      = var.traefik_frontend.units
+  app_name   = var.traefik_frontend.app_name
+  channel    = var.traefik_frontend.channel
+  revision   = var.traefik_frontend.revision
   config     = var.traefik_frontend.config
-
-  charm {
-    name     = "traefik-k8s"
-    channel  = var.traefik_frontend.channel
-    revision = var.traefik_frontend.revision
-  }
-}
-
-resource "juju_application" "traefik_gms" {
-  name       = var.traefik_gms.app_name
-  model_uuid = var.k8s_model_uuid
+  units      = var.traefik_frontend.units
   trust      = true
-  units      = var.traefik_gms.units
-  config     = var.traefik_gms.config
-
-  charm {
-    name     = "traefik-k8s"
-    channel  = var.traefik_gms.channel
-    revision = var.traefik_gms.revision
-  }
 }
 
-resource "juju_application" "self_signed_certificates" {
-  name       = var.self_signed_certificates.app_name
-  model_uuid = var.k8s_model_uuid
-  units      = var.self_signed_certificates.units
-  config     = var.self_signed_certificates.config
+module "traefik_gms" {
+  source = "./modules/traefik-k8s"
 
-  charm {
-    name     = "self-signed-certificates"
-    channel  = var.self_signed_certificates.channel
-    revision = var.self_signed_certificates.revision
-  }
+  model_uuid = var.k8s_model_uuid
+  app_name   = var.traefik_gms.app_name
+  channel    = var.traefik_gms.channel
+  revision   = var.traefik_gms.revision
+  config     = var.traefik_gms.config
+  units      = var.traefik_gms.units
+  trust      = true
+}
+
+module "self_signed_certificates" {
+  source = "./modules/self-signed-certificates"
+
+  model_uuid  = var.k8s_model_uuid
+  app_name    = var.self_signed_certificates.app_name
+  channel     = var.self_signed_certificates.channel
+  revision    = var.self_signed_certificates.revision
+  base        = var.self_signed_certificates.base
+  constraints = var.self_signed_certificates.constraints
+  config      = var.self_signed_certificates.config
+  units       = var.self_signed_certificates.units
 }
 
 ### INTEGRATIONS: DataHub to the data platform (cross-model, via offers)
@@ -172,8 +168,8 @@ resource "juju_integration" "datahub_frontend_ingress" {
   }
 
   application {
-    name     = juju_application.traefik_frontend.name
-    endpoint = "ingress"
+    name     = module.traefik_frontend.provides.ingress.name
+    endpoint = module.traefik_frontend.provides.ingress.endpoint
   }
 }
 
@@ -186,8 +182,8 @@ resource "juju_integration" "datahub_gms_ingress" {
   }
 
   application {
-    name     = juju_application.traefik_gms.name
-    endpoint = "ingress"
+    name     = module.traefik_gms.provides.ingress.name
+    endpoint = module.traefik_gms.provides.ingress.endpoint
   }
 }
 
@@ -195,13 +191,13 @@ resource "juju_integration" "traefik_frontend_certificates" {
   model_uuid = var.k8s_model_uuid
 
   application {
-    name     = juju_application.traefik_frontend.name
-    endpoint = "certificates"
+    name     = module.traefik_frontend.requires.certificates.name
+    endpoint = module.traefik_frontend.requires.certificates.endpoint
   }
 
   application {
-    name     = juju_application.self_signed_certificates.name
-    endpoint = "certificates"
+    name     = module.self_signed_certificates.provides.certificates.name
+    endpoint = module.self_signed_certificates.provides.certificates.endpoint
   }
 }
 
@@ -209,13 +205,13 @@ resource "juju_integration" "traefik_gms_certificates" {
   model_uuid = var.k8s_model_uuid
 
   application {
-    name     = juju_application.traefik_gms.name
-    endpoint = "certificates"
+    name     = module.traefik_gms.requires.certificates.name
+    endpoint = module.traefik_gms.requires.certificates.endpoint
   }
 
   application {
-    name     = juju_application.self_signed_certificates.name
-    endpoint = "certificates"
+    name     = module.self_signed_certificates.provides.certificates.name
+    endpoint = module.self_signed_certificates.provides.certificates.endpoint
   }
 }
 

--- a/terraform/product/modules/dependencies/main.tf
+++ b/terraform/product/modules/dependencies/main.tf
@@ -1,0 +1,144 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+### APPLICATIONS
+
+resource "juju_application" "postgresql" {
+  name        = var.postgresql.app_name
+  model_uuid  = var.model_uuid
+  units       = var.postgresql.units
+  constraints = var.postgresql.constraints
+  config      = var.postgresql.config
+
+  charm {
+    name     = "postgresql"
+    channel  = var.postgresql.channel
+    revision = var.postgresql.revision
+    base     = var.postgresql.base
+  }
+}
+
+resource "juju_application" "kafka" {
+  name        = var.kafka.app_name
+  model_uuid  = var.model_uuid
+  units       = var.kafka.units
+  constraints = var.kafka.constraints
+  config      = var.kafka.config
+
+  charm {
+    name     = "kafka"
+    channel  = var.kafka.channel
+    revision = var.kafka.revision
+    base     = var.kafka.base
+  }
+
+  expose {
+    endpoints = "kafka-client"
+  }
+}
+
+resource "juju_application" "zookeeper" {
+  name        = var.zookeeper.app_name
+  model_uuid  = var.model_uuid
+  units       = var.zookeeper.units
+  constraints = var.zookeeper.constraints
+  config      = var.zookeeper.config
+
+  charm {
+    name     = "zookeeper"
+    channel  = var.zookeeper.channel
+    revision = var.zookeeper.revision
+    base     = var.zookeeper.base
+  }
+}
+
+resource "juju_application" "opensearch" {
+  name        = var.opensearch.app_name
+  model_uuid  = var.model_uuid
+  units       = var.opensearch.units
+  constraints = var.opensearch.constraints
+  config      = var.opensearch.config
+
+  charm {
+    name     = "opensearch"
+    channel  = var.opensearch.channel
+    revision = var.opensearch.revision
+    base     = var.opensearch.base
+  }
+
+  expose {
+    endpoints = "opensearch-client"
+  }
+}
+
+resource "juju_application" "self_signed_certificates" {
+  name        = var.self_signed_certificates.app_name
+  model_uuid  = var.model_uuid
+  units       = var.self_signed_certificates.units
+  constraints = var.self_signed_certificates.constraints
+  config      = var.self_signed_certificates.config
+
+  charm {
+    name     = "self-signed-certificates"
+    channel  = var.self_signed_certificates.channel
+    revision = var.self_signed_certificates.revision
+    base     = var.self_signed_certificates.base
+  }
+}
+
+### INTEGRATIONS
+
+resource "juju_integration" "kafka_zookeeper" {
+  model_uuid = var.model_uuid
+
+  application {
+    name     = juju_application.kafka.name
+    endpoint = "zookeeper"
+  }
+
+  application {
+    name     = juju_application.zookeeper.name
+    endpoint = "zookeeper"
+  }
+}
+
+resource "juju_integration" "opensearch_certificates" {
+  model_uuid = var.model_uuid
+
+  application {
+    name     = juju_application.opensearch.name
+    endpoint = "certificates"
+  }
+
+  application {
+    name     = juju_application.self_signed_certificates.name
+    endpoint = "certificates"
+  }
+}
+
+### OFFERS
+
+resource "juju_offer" "database" {
+  model_uuid       = var.model_uuid
+  name             = "database"
+  application_name = juju_application.postgresql.name
+  endpoints        = ["database"]
+}
+
+resource "juju_offer" "kafka_client" {
+  model_uuid       = var.model_uuid
+  name             = "kafka-client"
+  application_name = juju_application.kafka.name
+  endpoints        = ["kafka-client"]
+
+  depends_on = [juju_integration.kafka_zookeeper]
+}
+
+resource "juju_offer" "opensearch_client" {
+  model_uuid       = var.model_uuid
+  name             = "opensearch-client"
+  application_name = juju_application.opensearch.name
+  endpoints        = ["opensearch-client"]
+
+  depends_on = [juju_integration.opensearch_certificates]
+}

--- a/terraform/product/modules/dependencies/main.tf
+++ b/terraform/product/modules/dependencies/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2026 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 ### APPLICATIONS

--- a/terraform/product/modules/dependencies/main.tf
+++ b/terraform/product/modules/dependencies/main.tf
@@ -1,93 +1,82 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-### APPLICATIONS
+# Data-platform component module: composes the per-charm modules and wires their in-model
+# integrations and the cross-model offers consumed by DataHub.
+#
+# The charm modules below are local stopgaps that adhere to the CC008 charm-module interface.
+# Once the upstream charms publish official Terraform modules, swap each `source` to the pinned
+# upstream reference.
 
-resource "juju_application" "postgresql" {
-  name               = var.postgresql.app_name
+### CHARM MODULES
+
+module "postgresql" {
+  source = "../postgresql"
+
   model_uuid         = var.model_uuid
-  units              = var.postgresql.units
+  app_name           = var.postgresql.app_name
+  channel            = var.postgresql.channel
+  revision           = var.postgresql.revision
+  base               = var.postgresql.base
   constraints        = var.postgresql.constraints
   config             = var.postgresql.config
   storage_directives = var.postgresql.storage_directives
-
-  charm {
-    name     = "postgresql"
-    channel  = var.postgresql.channel
-    revision = var.postgresql.revision
-    base     = var.postgresql.base
-  }
+  units              = var.postgresql.units
 }
 
-resource "juju_application" "kafka" {
-  name               = var.kafka.app_name
+module "kafka" {
+  source = "../kafka"
+
   model_uuid         = var.model_uuid
-  units              = var.kafka.units
+  app_name           = var.kafka.app_name
+  channel            = var.kafka.channel
+  revision           = var.kafka.revision
+  base               = var.kafka.base
   constraints        = var.kafka.constraints
   config             = var.kafka.config
   storage_directives = var.kafka.storage_directives
-
-  charm {
-    name     = "kafka"
-    channel  = var.kafka.channel
-    revision = var.kafka.revision
-    base     = var.kafka.base
-  }
-
-  expose {
-    endpoints = "kafka-client"
-  }
+  units              = var.kafka.units
 }
 
-resource "juju_application" "zookeeper" {
-  name               = var.zookeeper.app_name
+module "zookeeper" {
+  source = "../zookeeper"
+
   model_uuid         = var.model_uuid
-  units              = var.zookeeper.units
+  app_name           = var.zookeeper.app_name
+  channel            = var.zookeeper.channel
+  revision           = var.zookeeper.revision
+  base               = var.zookeeper.base
   constraints        = var.zookeeper.constraints
   config             = var.zookeeper.config
   storage_directives = var.zookeeper.storage_directives
-
-  charm {
-    name     = "zookeeper"
-    channel  = var.zookeeper.channel
-    revision = var.zookeeper.revision
-    base     = var.zookeeper.base
-  }
+  units              = var.zookeeper.units
 }
 
-resource "juju_application" "opensearch" {
-  name               = var.opensearch.app_name
+module "opensearch" {
+  source = "../opensearch"
+
   model_uuid         = var.model_uuid
-  units              = var.opensearch.units
+  app_name           = var.opensearch.app_name
+  channel            = var.opensearch.channel
+  revision           = var.opensearch.revision
+  base               = var.opensearch.base
   constraints        = var.opensearch.constraints
   config             = var.opensearch.config
   storage_directives = var.opensearch.storage_directives
-
-  charm {
-    name     = "opensearch"
-    channel  = var.opensearch.channel
-    revision = var.opensearch.revision
-    base     = var.opensearch.base
-  }
-
-  expose {
-    endpoints = "opensearch-client"
-  }
+  units              = var.opensearch.units
 }
 
-resource "juju_application" "self_signed_certificates" {
-  name        = var.self_signed_certificates.app_name
+module "self_signed_certificates" {
+  source = "../self-signed-certificates"
+
   model_uuid  = var.model_uuid
-  units       = var.self_signed_certificates.units
+  app_name    = var.self_signed_certificates.app_name
+  channel     = var.self_signed_certificates.channel
+  revision    = var.self_signed_certificates.revision
+  base        = var.self_signed_certificates.base
   constraints = var.self_signed_certificates.constraints
   config      = var.self_signed_certificates.config
-
-  charm {
-    name     = "self-signed-certificates"
-    channel  = var.self_signed_certificates.channel
-    revision = var.self_signed_certificates.revision
-    base     = var.self_signed_certificates.base
-  }
+  units       = var.self_signed_certificates.units
 }
 
 ### INTEGRATIONS
@@ -96,13 +85,13 @@ resource "juju_integration" "kafka_zookeeper" {
   model_uuid = var.model_uuid
 
   application {
-    name     = juju_application.kafka.name
-    endpoint = "zookeeper"
+    name     = module.kafka.requires.zookeeper.name
+    endpoint = module.kafka.requires.zookeeper.endpoint
   }
 
   application {
-    name     = juju_application.zookeeper.name
-    endpoint = "zookeeper"
+    name     = module.zookeeper.provides.zookeeper.name
+    endpoint = module.zookeeper.provides.zookeeper.endpoint
   }
 }
 
@@ -110,13 +99,13 @@ resource "juju_integration" "opensearch_certificates" {
   model_uuid = var.model_uuid
 
   application {
-    name     = juju_application.opensearch.name
-    endpoint = "certificates"
+    name     = module.opensearch.requires.certificates.name
+    endpoint = module.opensearch.requires.certificates.endpoint
   }
 
   application {
-    name     = juju_application.self_signed_certificates.name
-    endpoint = "certificates"
+    name     = module.self_signed_certificates.provides.certificates.name
+    endpoint = module.self_signed_certificates.provides.certificates.endpoint
   }
 }
 
@@ -125,14 +114,14 @@ resource "juju_integration" "opensearch_certificates" {
 resource "juju_offer" "database" {
   model_uuid       = var.model_uuid
   name             = "database"
-  application_name = juju_application.postgresql.name
+  application_name = module.postgresql.application.name
   endpoints        = ["database"]
 }
 
 resource "juju_offer" "kafka_client" {
   model_uuid       = var.model_uuid
   name             = "kafka-client"
-  application_name = juju_application.kafka.name
+  application_name = module.kafka.application.name
   endpoints        = ["kafka-client"]
 
   depends_on = [juju_integration.kafka_zookeeper]
@@ -141,7 +130,7 @@ resource "juju_offer" "kafka_client" {
 resource "juju_offer" "opensearch_client" {
   model_uuid       = var.model_uuid
   name             = "opensearch-client"
-  application_name = juju_application.opensearch.name
+  application_name = module.opensearch.application.name
   endpoints        = ["opensearch-client"]
 
   depends_on = [juju_integration.opensearch_certificates]

--- a/terraform/product/modules/dependencies/main.tf
+++ b/terraform/product/modules/dependencies/main.tf
@@ -4,11 +4,12 @@
 ### APPLICATIONS
 
 resource "juju_application" "postgresql" {
-  name        = var.postgresql.app_name
-  model_uuid  = var.model_uuid
-  units       = var.postgresql.units
-  constraints = var.postgresql.constraints
-  config      = var.postgresql.config
+  name               = var.postgresql.app_name
+  model_uuid         = var.model_uuid
+  units              = var.postgresql.units
+  constraints        = var.postgresql.constraints
+  config             = var.postgresql.config
+  storage_directives = var.postgresql.storage_directives
 
   charm {
     name     = "postgresql"
@@ -19,11 +20,12 @@ resource "juju_application" "postgresql" {
 }
 
 resource "juju_application" "kafka" {
-  name        = var.kafka.app_name
-  model_uuid  = var.model_uuid
-  units       = var.kafka.units
-  constraints = var.kafka.constraints
-  config      = var.kafka.config
+  name               = var.kafka.app_name
+  model_uuid         = var.model_uuid
+  units              = var.kafka.units
+  constraints        = var.kafka.constraints
+  config             = var.kafka.config
+  storage_directives = var.kafka.storage_directives
 
   charm {
     name     = "kafka"
@@ -38,11 +40,12 @@ resource "juju_application" "kafka" {
 }
 
 resource "juju_application" "zookeeper" {
-  name        = var.zookeeper.app_name
-  model_uuid  = var.model_uuid
-  units       = var.zookeeper.units
-  constraints = var.zookeeper.constraints
-  config      = var.zookeeper.config
+  name               = var.zookeeper.app_name
+  model_uuid         = var.model_uuid
+  units              = var.zookeeper.units
+  constraints        = var.zookeeper.constraints
+  config             = var.zookeeper.config
+  storage_directives = var.zookeeper.storage_directives
 
   charm {
     name     = "zookeeper"
@@ -53,11 +56,12 @@ resource "juju_application" "zookeeper" {
 }
 
 resource "juju_application" "opensearch" {
-  name        = var.opensearch.app_name
-  model_uuid  = var.model_uuid
-  units       = var.opensearch.units
-  constraints = var.opensearch.constraints
-  config      = var.opensearch.config
+  name               = var.opensearch.app_name
+  model_uuid         = var.model_uuid
+  units              = var.opensearch.units
+  constraints        = var.opensearch.constraints
+  config             = var.opensearch.config
+  storage_directives = var.opensearch.storage_directives
 
   charm {
     name     = "opensearch"

--- a/terraform/product/modules/dependencies/outputs.tf
+++ b/terraform/product/modules/dependencies/outputs.tf
@@ -1,14 +1,14 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-output "app_names" {
-  description = "Names of the deployed data-platform applications."
+output "components" {
+  description = "Objects representing the deployed data-platform applications."
   value = {
-    postgresql               = juju_application.postgresql.name
-    kafka                    = juju_application.kafka.name
-    zookeeper                = juju_application.zookeeper.name
-    opensearch               = juju_application.opensearch.name
-    self-signed-certificates = juju_application.self_signed_certificates.name
+    postgresql               = module.postgresql.application
+    kafka                    = module.kafka.application
+    zookeeper                = module.zookeeper.application
+    opensearch               = module.opensearch.application
+    self-signed-certificates = module.self_signed_certificates.application
   }
 }
 
@@ -18,5 +18,24 @@ output "offers" {
     database          = juju_offer.database.url
     kafka_client      = juju_offer.kafka_client.url
     opensearch_client = juju_offer.opensearch_client.url
+  }
+}
+
+output "provides" {
+  description = "Provided endpoints across the data-platform charms (<charm>_<endpoint>)."
+  value = {
+    postgresql_database                   = module.postgresql.provides.database
+    kafka_kafka_client                    = module.kafka.provides.kafka_client
+    zookeeper_zookeeper                   = module.zookeeper.provides.zookeeper
+    opensearch_opensearch_client          = module.opensearch.provides.opensearch_client
+    self_signed_certificates_certificates = module.self_signed_certificates.provides.certificates
+  }
+}
+
+output "requires" {
+  description = "Required endpoints across the data-platform charms (<charm>_<endpoint>)."
+  value = {
+    kafka_zookeeper         = module.kafka.requires.zookeeper
+    opensearch_certificates = module.opensearch.requires.certificates
   }
 }

--- a/terraform/product/modules/dependencies/outputs.tf
+++ b/terraform/product/modules/dependencies/outputs.tf
@@ -1,4 +1,4 @@
-# Copyright 2026 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 output "app_names" {

--- a/terraform/product/modules/dependencies/outputs.tf
+++ b/terraform/product/modules/dependencies/outputs.tf
@@ -1,0 +1,22 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+output "app_names" {
+  description = "Names of the deployed data-platform applications."
+  value = {
+    postgresql               = juju_application.postgresql.name
+    kafka                    = juju_application.kafka.name
+    zookeeper                = juju_application.zookeeper.name
+    opensearch               = juju_application.opensearch.name
+    self-signed-certificates = juju_application.self_signed_certificates.name
+  }
+}
+
+output "offers" {
+  description = "Cross-model offer URLs for the data-platform endpoints consumed by DataHub."
+  value = {
+    database          = juju_offer.database.url
+    kafka_client      = juju_offer.kafka_client.url
+    opensearch_client = juju_offer.opensearch_client.url
+  }
+}

--- a/terraform/product/modules/dependencies/terraform.tf
+++ b/terraform/product/modules/dependencies/terraform.tf
@@ -1,4 +1,4 @@
-# Copyright 2026 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 terraform {

--- a/terraform/product/modules/dependencies/terraform.tf
+++ b/terraform/product/modules/dependencies/terraform.tf
@@ -2,11 +2,11 @@
 # See LICENSE file for licensing details.
 
 terraform {
-  required_version = "~> 1.12"
+  required_version = "~> 1.14"
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 1.0"
+      version = "~> 2.0"
     }
   }
 }

--- a/terraform/product/modules/dependencies/terraform.tf
+++ b/terraform/product/modules/dependencies/terraform.tf
@@ -1,0 +1,12 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+terraform {
+  required_version = "~> 1.12"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 1.0"
+    }
+  }
+}

--- a/terraform/product/modules/dependencies/variables.tf
+++ b/terraform/product/modules/dependencies/variables.tf
@@ -1,4 +1,4 @@
-# Copyright 2026 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 variable "model_uuid" {

--- a/terraform/product/modules/dependencies/variables.tf
+++ b/terraform/product/modules/dependencies/variables.tf
@@ -9,13 +9,14 @@ variable "model_uuid" {
 variable "kafka" {
   description = "Configuration for the Kafka charm."
   type = object({
-    app_name    = optional(string, "kafka")
-    channel     = optional(string, "3/stable")
-    revision    = optional(number)
-    base        = optional(string, "ubuntu@22.04")
-    constraints = optional(string, "arch=amd64")
-    config      = optional(map(string), {})
-    units       = optional(number, 1)
+    app_name           = optional(string, "kafka")
+    channel            = optional(string, "3/stable")
+    revision           = optional(number)
+    base               = optional(string, "ubuntu@22.04")
+    constraints        = optional(string, "arch=amd64")
+    config             = optional(map(string), {})
+    storage_directives = optional(map(string), {})
+    units              = optional(number, 1)
   })
   default = {}
 }
@@ -23,13 +24,14 @@ variable "kafka" {
 variable "opensearch" {
   description = "Configuration for the OpenSearch charm."
   type = object({
-    app_name    = optional(string, "opensearch")
-    channel     = optional(string, "2/stable")
-    revision    = optional(number)
-    base        = optional(string, "ubuntu@22.04")
-    constraints = optional(string, "arch=amd64")
-    config      = optional(map(string), {})
-    units       = optional(number, 2)
+    app_name           = optional(string, "opensearch")
+    channel            = optional(string, "2/stable")
+    revision           = optional(number)
+    base               = optional(string, "ubuntu@22.04")
+    constraints        = optional(string, "arch=amd64")
+    config             = optional(map(string), {})
+    storage_directives = optional(map(string), {})
+    units              = optional(number, 2)
   })
   default = {}
 }
@@ -37,13 +39,14 @@ variable "opensearch" {
 variable "postgresql" {
   description = "Configuration for the PostgreSQL charm."
   type = object({
-    app_name    = optional(string, "postgresql")
-    channel     = optional(string, "14/stable")
-    revision    = optional(number)
-    base        = optional(string, "ubuntu@22.04")
-    constraints = optional(string, "arch=amd64")
-    config      = optional(map(string), {})
-    units       = optional(number, 1)
+    app_name           = optional(string, "postgresql")
+    channel            = optional(string, "14/stable")
+    revision           = optional(number)
+    base               = optional(string, "ubuntu@22.04")
+    constraints        = optional(string, "arch=amd64")
+    config             = optional(map(string), {})
+    storage_directives = optional(map(string), {})
+    units              = optional(number, 1)
   })
   default = {}
 }
@@ -65,13 +68,14 @@ variable "self_signed_certificates" {
 variable "zookeeper" {
   description = "Configuration for the ZooKeeper charm (backend for Kafka)."
   type = object({
-    app_name    = optional(string, "zookeeper")
-    channel     = optional(string, "3/stable")
-    revision    = optional(number)
-    base        = optional(string, "ubuntu@22.04")
-    constraints = optional(string, "arch=amd64")
-    config      = optional(map(string), {})
-    units       = optional(number, 1)
+    app_name           = optional(string, "zookeeper")
+    channel            = optional(string, "3/stable")
+    revision           = optional(number)
+    base               = optional(string, "ubuntu@22.04")
+    constraints        = optional(string, "arch=amd64")
+    config             = optional(map(string), {})
+    storage_directives = optional(map(string), {})
+    units              = optional(number, 1)
   })
   default = {}
 }

--- a/terraform/product/modules/dependencies/variables.tf
+++ b/terraform/product/modules/dependencies/variables.tf
@@ -1,0 +1,77 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+variable "model_uuid" {
+  description = "UUID of the (machine) Juju model to deploy the data platform into."
+  type        = string
+}
+
+variable "kafka" {
+  description = "Configuration for the Kafka charm."
+  type = object({
+    app_name    = optional(string, "kafka")
+    channel     = optional(string, "3/stable")
+    revision    = optional(number)
+    base        = optional(string, "ubuntu@22.04")
+    constraints = optional(string, "arch=amd64")
+    config      = optional(map(string), {})
+    units       = optional(number, 1)
+  })
+  default = {}
+}
+
+variable "opensearch" {
+  description = "Configuration for the OpenSearch charm."
+  type = object({
+    app_name    = optional(string, "opensearch")
+    channel     = optional(string, "2/stable")
+    revision    = optional(number)
+    base        = optional(string, "ubuntu@22.04")
+    constraints = optional(string, "arch=amd64")
+    config      = optional(map(string), {})
+    units       = optional(number, 2)
+  })
+  default = {}
+}
+
+variable "postgresql" {
+  description = "Configuration for the PostgreSQL charm."
+  type = object({
+    app_name    = optional(string, "postgresql")
+    channel     = optional(string, "14/stable")
+    revision    = optional(number)
+    base        = optional(string, "ubuntu@22.04")
+    constraints = optional(string, "arch=amd64")
+    config      = optional(map(string), {})
+    units       = optional(number, 1)
+  })
+  default = {}
+}
+
+variable "self_signed_certificates" {
+  description = "Configuration for the self-signed-certificates charm (TLS for OpenSearch)."
+  type = object({
+    app_name    = optional(string, "self-signed-certificates")
+    channel     = optional(string, "latest/stable")
+    revision    = optional(number)
+    base        = optional(string, "ubuntu@22.04")
+    constraints = optional(string, "arch=amd64")
+    config      = optional(map(string), {})
+    units       = optional(number, 1)
+  })
+  default = {}
+}
+
+variable "zookeeper" {
+  description = "Configuration for the ZooKeeper charm (backend for Kafka)."
+  type = object({
+    app_name    = optional(string, "zookeeper")
+    channel     = optional(string, "3/stable")
+    revision    = optional(number)
+    base        = optional(string, "ubuntu@22.04")
+    constraints = optional(string, "arch=amd64")
+    config      = optional(map(string), {})
+    units       = optional(number, 1)
+  })
+  default = {}
+}

--- a/terraform/product/modules/kafka/main.tf
+++ b/terraform/product/modules/kafka/main.tf
@@ -1,0 +1,24 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+resource "juju_application" "kafka" {
+  name        = var.app_name
+  model_uuid  = var.model_uuid
+  units       = var.units
+  constraints = var.constraints
+  config      = var.config
+
+  storage_directives = var.storage_directives
+
+  charm {
+    name     = "kafka"
+    channel  = var.channel
+    revision = var.revision
+    base     = var.base
+  }
+
+  # Expose kafka-client so the cross-model offer is reachable from the consuming model.
+  expose {
+    endpoints = "kafka-client"
+  }
+}

--- a/terraform/product/modules/kafka/outputs.tf
+++ b/terraform/product/modules/kafka/outputs.tf
@@ -1,0 +1,27 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+output "application" {
+  description = "Object representing the deployed application."
+  value       = juju_application.kafka
+}
+
+output "provides" {
+  description = "Map of all the provided endpoints."
+  value = {
+    kafka_client = {
+      name     = juju_application.kafka.name
+      endpoint = "kafka-client"
+    }
+  }
+}
+
+output "requires" {
+  description = "Map of all the required endpoints."
+  value = {
+    zookeeper = {
+      name     = juju_application.kafka.name
+      endpoint = "zookeeper"
+    }
+  }
+}

--- a/terraform/product/modules/kafka/terraform.tf
+++ b/terraform/product/modules/kafka/terraform.tf
@@ -2,11 +2,11 @@
 # See LICENSE file for licensing details.
 
 terraform {
-  required_version = "~> 1.12"
+  required_version = "~> 1.14"
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 1.0"
+      version = "~> 2.0"
     }
   }
 }

--- a/terraform/product/modules/kafka/terraform.tf
+++ b/terraform/product/modules/kafka/terraform.tf
@@ -1,0 +1,12 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+terraform {
+  required_version = "~> 1.12"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 1.0"
+    }
+  }
+}

--- a/terraform/product/modules/kafka/variables.tf
+++ b/terraform/product/modules/kafka/variables.tf
@@ -1,0 +1,58 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+variable "app_name" {
+  description = "Name to give the deployed application."
+  type        = string
+  default     = "kafka"
+  nullable    = false
+}
+
+variable "base" {
+  description = "The operating system on which to deploy. E.g. ubuntu@22.04."
+  type        = string
+  default     = "ubuntu@22.04"
+}
+
+variable "channel" {
+  description = "Channel of the charm."
+  type        = string
+  default     = "3/stable"
+  nullable    = false
+}
+
+variable "config" {
+  description = "Map for configuration options."
+  type        = map(string)
+  default     = {}
+}
+
+variable "constraints" {
+  description = "String listing constraints for this application."
+  type        = string
+  default     = "arch=amd64"
+}
+
+variable "model_uuid" {
+  description = "Reference to an existing model uuid."
+  type        = string
+  nullable    = false
+}
+
+variable "revision" {
+  description = "Revision number of the charm."
+  type        = number
+  default     = null
+}
+
+variable "storage_directives" {
+  description = "Map of storage directives (label -> [<pool>,][<count>,][<size>])."
+  type        = map(string)
+  default     = {}
+}
+
+variable "units" {
+  description = "Unit count/scale."
+  type        = number
+  default     = 1
+}

--- a/terraform/product/modules/opensearch/main.tf
+++ b/terraform/product/modules/opensearch/main.tf
@@ -1,0 +1,24 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+resource "juju_application" "opensearch" {
+  name        = var.app_name
+  model_uuid  = var.model_uuid
+  units       = var.units
+  constraints = var.constraints
+  config      = var.config
+
+  storage_directives = var.storage_directives
+
+  charm {
+    name     = "opensearch"
+    channel  = var.channel
+    revision = var.revision
+    base     = var.base
+  }
+
+  # Expose opensearch-client so the cross-model offer is reachable from the consuming model.
+  expose {
+    endpoints = "opensearch-client"
+  }
+}

--- a/terraform/product/modules/opensearch/outputs.tf
+++ b/terraform/product/modules/opensearch/outputs.tf
@@ -1,0 +1,27 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+output "application" {
+  description = "Object representing the deployed application."
+  value       = juju_application.opensearch
+}
+
+output "provides" {
+  description = "Map of all the provided endpoints."
+  value = {
+    opensearch_client = {
+      name     = juju_application.opensearch.name
+      endpoint = "opensearch-client"
+    }
+  }
+}
+
+output "requires" {
+  description = "Map of all the required endpoints."
+  value = {
+    certificates = {
+      name     = juju_application.opensearch.name
+      endpoint = "certificates"
+    }
+  }
+}

--- a/terraform/product/modules/opensearch/terraform.tf
+++ b/terraform/product/modules/opensearch/terraform.tf
@@ -2,11 +2,11 @@
 # See LICENSE file for licensing details.
 
 terraform {
-  required_version = "~> 1.12"
+  required_version = "~> 1.14"
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 1.0"
+      version = "~> 2.0"
     }
   }
 }

--- a/terraform/product/modules/opensearch/terraform.tf
+++ b/terraform/product/modules/opensearch/terraform.tf
@@ -1,0 +1,12 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+terraform {
+  required_version = "~> 1.12"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 1.0"
+    }
+  }
+}

--- a/terraform/product/modules/opensearch/variables.tf
+++ b/terraform/product/modules/opensearch/variables.tf
@@ -1,0 +1,58 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+variable "app_name" {
+  description = "Name to give the deployed application."
+  type        = string
+  default     = "opensearch"
+  nullable    = false
+}
+
+variable "base" {
+  description = "The operating system on which to deploy. E.g. ubuntu@22.04."
+  type        = string
+  default     = "ubuntu@22.04"
+}
+
+variable "channel" {
+  description = "Channel of the charm."
+  type        = string
+  default     = "2/stable"
+  nullable    = false
+}
+
+variable "config" {
+  description = "Map for configuration options."
+  type        = map(string)
+  default     = {}
+}
+
+variable "constraints" {
+  description = "String listing constraints for this application."
+  type        = string
+  default     = "arch=amd64"
+}
+
+variable "model_uuid" {
+  description = "Reference to an existing model uuid."
+  type        = string
+  nullable    = false
+}
+
+variable "revision" {
+  description = "Revision number of the charm."
+  type        = number
+  default     = null
+}
+
+variable "storage_directives" {
+  description = "Map of storage directives (label -> [<pool>,][<count>,][<size>])."
+  type        = map(string)
+  default     = {}
+}
+
+variable "units" {
+  description = "Unit count/scale."
+  type        = number
+  default     = 1
+}

--- a/terraform/product/modules/postgresql/main.tf
+++ b/terraform/product/modules/postgresql/main.tf
@@ -1,0 +1,19 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+resource "juju_application" "postgresql" {
+  name        = var.app_name
+  model_uuid  = var.model_uuid
+  units       = var.units
+  constraints = var.constraints
+  config      = var.config
+
+  storage_directives = var.storage_directives
+
+  charm {
+    name     = "postgresql"
+    channel  = var.channel
+    revision = var.revision
+    base     = var.base
+  }
+}

--- a/terraform/product/modules/postgresql/outputs.tf
+++ b/terraform/product/modules/postgresql/outputs.tf
@@ -1,0 +1,22 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+output "application" {
+  description = "Object representing the deployed application."
+  value       = juju_application.postgresql
+}
+
+output "provides" {
+  description = "Map of all the provided endpoints."
+  value = {
+    database = {
+      name     = juju_application.postgresql.name
+      endpoint = "database"
+    }
+  }
+}
+
+output "requires" {
+  description = "Map of all the required endpoints."
+  value       = {}
+}

--- a/terraform/product/modules/postgresql/terraform.tf
+++ b/terraform/product/modules/postgresql/terraform.tf
@@ -2,11 +2,11 @@
 # See LICENSE file for licensing details.
 
 terraform {
-  required_version = "~> 1.12"
+  required_version = "~> 1.14"
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 1.0"
+      version = "~> 2.0"
     }
   }
 }

--- a/terraform/product/modules/postgresql/terraform.tf
+++ b/terraform/product/modules/postgresql/terraform.tf
@@ -1,0 +1,12 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+terraform {
+  required_version = "~> 1.12"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 1.0"
+    }
+  }
+}

--- a/terraform/product/modules/postgresql/variables.tf
+++ b/terraform/product/modules/postgresql/variables.tf
@@ -1,0 +1,58 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+variable "app_name" {
+  description = "Name to give the deployed application."
+  type        = string
+  default     = "postgresql"
+  nullable    = false
+}
+
+variable "base" {
+  description = "The operating system on which to deploy. E.g. ubuntu@22.04."
+  type        = string
+  default     = "ubuntu@22.04"
+}
+
+variable "channel" {
+  description = "Channel of the charm."
+  type        = string
+  default     = "14/stable"
+  nullable    = false
+}
+
+variable "config" {
+  description = "Map for configuration options."
+  type        = map(string)
+  default     = {}
+}
+
+variable "constraints" {
+  description = "String listing constraints for this application."
+  type        = string
+  default     = "arch=amd64"
+}
+
+variable "model_uuid" {
+  description = "Reference to an existing model uuid."
+  type        = string
+  nullable    = false
+}
+
+variable "revision" {
+  description = "Revision number of the charm."
+  type        = number
+  default     = null
+}
+
+variable "storage_directives" {
+  description = "Map of storage directives (label -> [<pool>,][<count>,][<size>])."
+  type        = map(string)
+  default     = {}
+}
+
+variable "units" {
+  description = "Unit count/scale."
+  type        = number
+  default     = 1
+}

--- a/terraform/product/modules/self-signed-certificates/main.tf
+++ b/terraform/product/modules/self-signed-certificates/main.tf
@@ -1,0 +1,17 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+resource "juju_application" "self_signed_certificates" {
+  name        = var.app_name
+  model_uuid  = var.model_uuid
+  units       = var.units
+  constraints = var.constraints
+  config      = var.config
+
+  charm {
+    name     = "self-signed-certificates"
+    channel  = var.channel
+    revision = var.revision
+    base     = var.base
+  }
+}

--- a/terraform/product/modules/self-signed-certificates/outputs.tf
+++ b/terraform/product/modules/self-signed-certificates/outputs.tf
@@ -1,0 +1,22 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+output "application" {
+  description = "Object representing the deployed application."
+  value       = juju_application.self_signed_certificates
+}
+
+output "provides" {
+  description = "Map of all the provided endpoints."
+  value = {
+    certificates = {
+      name     = juju_application.self_signed_certificates.name
+      endpoint = "certificates"
+    }
+  }
+}
+
+output "requires" {
+  description = "Map of all the required endpoints."
+  value       = {}
+}

--- a/terraform/product/modules/self-signed-certificates/terraform.tf
+++ b/terraform/product/modules/self-signed-certificates/terraform.tf
@@ -2,11 +2,11 @@
 # See LICENSE file for licensing details.
 
 terraform {
-  required_version = "~> 1.12"
+  required_version = "~> 1.14"
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 1.0"
+      version = "~> 2.0"
     }
   }
 }

--- a/terraform/product/modules/self-signed-certificates/terraform.tf
+++ b/terraform/product/modules/self-signed-certificates/terraform.tf
@@ -1,0 +1,12 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+terraform {
+  required_version = "~> 1.12"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 1.0"
+    }
+  }
+}

--- a/terraform/product/modules/self-signed-certificates/variables.tf
+++ b/terraform/product/modules/self-signed-certificates/variables.tf
@@ -1,0 +1,52 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+variable "app_name" {
+  description = "Name to give the deployed application."
+  type        = string
+  default     = "self-signed-certificates"
+  nullable    = false
+}
+
+variable "base" {
+  description = "The operating system on which to deploy. E.g. ubuntu@22.04."
+  type        = string
+  default     = "ubuntu@22.04"
+}
+
+variable "channel" {
+  description = "Channel of the charm."
+  type        = string
+  default     = "latest/stable"
+  nullable    = false
+}
+
+variable "config" {
+  description = "Map for configuration options."
+  type        = map(string)
+  default     = {}
+}
+
+variable "constraints" {
+  description = "String listing constraints for this application."
+  type        = string
+  default     = "arch=amd64"
+}
+
+variable "model_uuid" {
+  description = "Reference to an existing model uuid."
+  type        = string
+  nullable    = false
+}
+
+variable "revision" {
+  description = "Revision number of the charm."
+  type        = number
+  default     = null
+}
+
+variable "units" {
+  description = "Unit count/scale."
+  type        = number
+  default     = 1
+}

--- a/terraform/product/modules/traefik-k8s/main.tf
+++ b/terraform/product/modules/traefik-k8s/main.tf
@@ -1,0 +1,16 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+resource "juju_application" "traefik_k8s" {
+  name       = var.app_name
+  model_uuid = var.model_uuid
+  units      = var.units
+  trust      = var.trust
+  config     = var.config
+
+  charm {
+    name     = "traefik-k8s"
+    channel  = var.channel
+    revision = var.revision
+  }
+}

--- a/terraform/product/modules/traefik-k8s/outputs.tf
+++ b/terraform/product/modules/traefik-k8s/outputs.tf
@@ -1,0 +1,27 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+output "application" {
+  description = "Object representing the deployed application."
+  value       = juju_application.traefik_k8s
+}
+
+output "provides" {
+  description = "Map of all the provided endpoints."
+  value = {
+    ingress = {
+      name     = juju_application.traefik_k8s.name
+      endpoint = "ingress"
+    }
+  }
+}
+
+output "requires" {
+  description = "Map of all the required endpoints."
+  value = {
+    certificates = {
+      name     = juju_application.traefik_k8s.name
+      endpoint = "certificates"
+    }
+  }
+}

--- a/terraform/product/modules/traefik-k8s/terraform.tf
+++ b/terraform/product/modules/traefik-k8s/terraform.tf
@@ -2,11 +2,11 @@
 # See LICENSE file for licensing details.
 
 terraform {
-  required_version = "~> 1.12"
+  required_version = "~> 1.14"
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 1.0"
+      version = "~> 2.0"
     }
   }
 }

--- a/terraform/product/modules/traefik-k8s/terraform.tf
+++ b/terraform/product/modules/traefik-k8s/terraform.tf
@@ -1,0 +1,12 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+terraform {
+  required_version = "~> 1.12"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 1.0"
+    }
+  }
+}

--- a/terraform/product/modules/traefik-k8s/variables.tf
+++ b/terraform/product/modules/traefik-k8s/variables.tf
@@ -1,0 +1,46 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+variable "app_name" {
+  description = "Name to give the deployed application."
+  type        = string
+  default     = "traefik-k8s"
+  nullable    = false
+}
+
+variable "channel" {
+  description = "Channel of the charm."
+  type        = string
+  default     = "latest/stable"
+  nullable    = false
+}
+
+variable "config" {
+  description = "Map for configuration options."
+  type        = map(string)
+  default     = {}
+}
+
+variable "model_uuid" {
+  description = "Reference to an existing model uuid."
+  type        = string
+  nullable    = false
+}
+
+variable "revision" {
+  description = "Revision number of the charm."
+  type        = number
+  default     = null
+}
+
+variable "trust" {
+  description = "Whether to grant the application access to the Kubernetes cluster (required for the load balancer)."
+  type        = bool
+  default     = false
+}
+
+variable "units" {
+  description = "Unit count/scale."
+  type        = number
+  default     = 1
+}

--- a/terraform/product/modules/zookeeper/main.tf
+++ b/terraform/product/modules/zookeeper/main.tf
@@ -1,0 +1,19 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+resource "juju_application" "zookeeper" {
+  name        = var.app_name
+  model_uuid  = var.model_uuid
+  units       = var.units
+  constraints = var.constraints
+  config      = var.config
+
+  storage_directives = var.storage_directives
+
+  charm {
+    name     = "zookeeper"
+    channel  = var.channel
+    revision = var.revision
+    base     = var.base
+  }
+}

--- a/terraform/product/modules/zookeeper/outputs.tf
+++ b/terraform/product/modules/zookeeper/outputs.tf
@@ -1,0 +1,22 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+output "application" {
+  description = "Object representing the deployed application."
+  value       = juju_application.zookeeper
+}
+
+output "provides" {
+  description = "Map of all the provided endpoints."
+  value = {
+    zookeeper = {
+      name     = juju_application.zookeeper.name
+      endpoint = "zookeeper"
+    }
+  }
+}
+
+output "requires" {
+  description = "Map of all the required endpoints."
+  value       = {}
+}

--- a/terraform/product/modules/zookeeper/terraform.tf
+++ b/terraform/product/modules/zookeeper/terraform.tf
@@ -2,11 +2,11 @@
 # See LICENSE file for licensing details.
 
 terraform {
-  required_version = "~> 1.12"
+  required_version = "~> 1.14"
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 1.0"
+      version = "~> 2.0"
     }
   }
 }

--- a/terraform/product/modules/zookeeper/terraform.tf
+++ b/terraform/product/modules/zookeeper/terraform.tf
@@ -1,0 +1,12 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+terraform {
+  required_version = "~> 1.12"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 1.0"
+    }
+  }
+}

--- a/terraform/product/modules/zookeeper/variables.tf
+++ b/terraform/product/modules/zookeeper/variables.tf
@@ -1,0 +1,58 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+variable "app_name" {
+  description = "Name to give the deployed application."
+  type        = string
+  default     = "zookeeper"
+  nullable    = false
+}
+
+variable "base" {
+  description = "The operating system on which to deploy. E.g. ubuntu@22.04."
+  type        = string
+  default     = "ubuntu@22.04"
+}
+
+variable "channel" {
+  description = "Channel of the charm."
+  type        = string
+  default     = "3/stable"
+  nullable    = false
+}
+
+variable "config" {
+  description = "Map for configuration options."
+  type        = map(string)
+  default     = {}
+}
+
+variable "constraints" {
+  description = "String listing constraints for this application."
+  type        = string
+  default     = "arch=amd64"
+}
+
+variable "model_uuid" {
+  description = "Reference to an existing model uuid."
+  type        = string
+  nullable    = false
+}
+
+variable "revision" {
+  description = "Revision number of the charm."
+  type        = number
+  default     = null
+}
+
+variable "storage_directives" {
+  description = "Map of storage directives (label -> [<pool>,][<count>,][<size>])."
+  type        = map(string)
+  default     = {}
+}
+
+variable "units" {
+  description = "Unit count/scale."
+  type        = number
+  default     = 1
+}

--- a/terraform/product/outputs.tf
+++ b/terraform/product/outputs.tf
@@ -17,14 +17,14 @@ output "models" {
       model_uuid = var.k8s_model_uuid
       components = {
         datahub-k8s              = module.datahub.app_name
-        traefik-frontend         = juju_application.traefik_frontend.name
-        traefik-gms              = juju_application.traefik_gms.name
-        self-signed-certificates = juju_application.self_signed_certificates.name
+        traefik-frontend         = module.traefik_frontend.application.name
+        traefik-gms              = module.traefik_gms.application.name
+        self-signed-certificates = module.self_signed_certificates.application.name
       }
     }
     data-platform = {
       model_uuid = local.deploy_deps ? var.machine_model_uuid : null
-      components = local.deploy_deps ? module.dependencies[0].app_names : {}
+      components = local.deploy_deps ? module.dependencies[0].components : {}
     }
   }
 }

--- a/terraform/product/outputs.tf
+++ b/terraform/product/outputs.tf
@@ -1,4 +1,4 @@
-# Copyright 2026 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 output "metadata" {

--- a/terraform/product/outputs.tf
+++ b/terraform/product/outputs.tf
@@ -1,0 +1,39 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+output "metadata" {
+  description = "Metadata of the product deployment."
+  value = {
+    version     = local.module_version
+    deployed_at = time_static.deployed_at.rfc3339
+    updated_at  = time_static.updated_at.rfc3339
+  }
+}
+
+output "models" {
+  description = "Map of the deployed models and the applications in each."
+  value = {
+    datahub = {
+      model_uuid = var.k8s_model_uuid
+      components = {
+        datahub-k8s              = module.datahub.app_name
+        traefik-frontend         = juju_application.traefik_frontend.name
+        traefik-gms              = juju_application.traefik_gms.name
+        self-signed-certificates = juju_application.self_signed_certificates.name
+      }
+    }
+    data-platform = {
+      model_uuid = local.deploy_deps ? var.machine_model_uuid : null
+      components = local.deploy_deps ? module.dependencies[0].app_names : {}
+    }
+  }
+}
+
+output "offers" {
+  description = "Data-platform offer URLs consumed by DataHub (in-module or externally provided)."
+  value = {
+    database          = local.database_offer
+    kafka_client      = local.kafka_offer
+    opensearch_client = local.opensearch_offer
+  }
+}

--- a/terraform/product/terraform.tf
+++ b/terraform/product/terraform.tf
@@ -1,4 +1,4 @@
-# Copyright 2026 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 terraform {

--- a/terraform/product/terraform.tf
+++ b/terraform/product/terraform.tf
@@ -1,0 +1,20 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+terraform {
+  required_version = "~> 1.12"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 1.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+    time = {
+      source  = "hashicorp/time"
+      version = "~> 0.12"
+    }
+  }
+}

--- a/terraform/product/terraform.tf
+++ b/terraform/product/terraform.tf
@@ -2,11 +2,11 @@
 # See LICENSE file for licensing details.
 
 terraform {
-  required_version = "~> 1.12"
+  required_version = "~> 1.14"
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 1.0"
+      version = "~> 2.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/terraform/product/tests/main.tftest.hcl
+++ b/terraform/product/tests/main.tftest.hcl
@@ -1,0 +1,25 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+run "setup_tests" {
+  module {
+    source = "./tests/setup"
+  }
+}
+
+run "full_deploy" {
+  variables {
+    k8s_model_uuid     = run.setup_tests.k8s_model_uuid
+    machine_model_uuid = run.setup_tests.machine_model_uuid
+  }
+
+  assert {
+    condition     = output.models.datahub.components["datahub-k8s"] == "datahub-k8s"
+    error_message = "datahub-k8s application not present in the datahub model components"
+  }
+
+  assert {
+    condition     = output.offers.database != "" && output.offers.kafka_client != "" && output.offers.opensearch_client != ""
+    error_message = "data-platform offer URLs were not produced"
+  }
+}

--- a/terraform/product/tests/main.tftest.hcl
+++ b/terraform/product/tests/main.tftest.hcl
@@ -1,4 +1,4 @@
-# Copyright 2026 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 run "setup_tests" {

--- a/terraform/product/tests/main.tftest.hcl
+++ b/terraform/product/tests/main.tftest.hcl
@@ -23,3 +23,39 @@ run "full_deploy" {
     error_message = "data-platform offer URLs were not produced"
   }
 }
+
+# OpenSearch is the long wait on the machine cloud; it only reaches active with the kernel sysctls
+# set by tests/setup/pre_run_script.sh (wired via the workflow's additional-setup-script).
+run "wait_for_opensearch_active" {
+  module {
+    source = "./tests/wait_for_active"
+  }
+
+  variables {
+    model_uuid = run.setup_tests.machine_model_uuid
+    app_name   = "opensearch"
+    timeout    = 1200
+  }
+
+  assert {
+    condition     = data.external.app_status.result.status == "active"
+    error_message = "opensearch did not reach active state"
+  }
+}
+
+run "wait_for_datahub_active" {
+  module {
+    source = "./tests/wait_for_active"
+  }
+
+  variables {
+    model_uuid = run.setup_tests.k8s_model_uuid
+    app_name   = "datahub-k8s"
+    timeout    = 1800
+  }
+
+  assert {
+    condition     = data.external.app_status.result.status == "active"
+    error_message = "datahub-k8s did not reach active state"
+  }
+}

--- a/terraform/product/tests/setup/main.tf
+++ b/terraform/product/tests/setup/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2026 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 terraform {

--- a/terraform/product/tests/setup/main.tf
+++ b/terraform/product/tests/setup/main.tf
@@ -18,10 +18,15 @@ resource "juju_model" "machine" {
 }
 
 resource "juju_model" "k8s" {
-  name = "tf-testing-dh-${formatdate("YYYYMMDDhhmmss", timestamp())}"
+  name       = "tf-testing-dh-${formatdate("YYYYMMDDhhmmss", timestamp())}"
+  credential = var.k8s_credential_name
 
   cloud {
     name = var.k8s_cloud_name
+  }
+
+  config = {
+    workload-storage = var.workload_storage_class
   }
 }
 
@@ -29,6 +34,18 @@ variable "k8s_cloud_name" {
   description = "Name of the Kubernetes cloud registered on the controller."
   type        = string
   default     = "microk8s"
+}
+
+variable "k8s_credential_name" {
+  description = "Name of the credential for the Kubernetes cloud."
+  type        = string
+  default     = "microk8s"
+}
+
+variable "workload_storage_class" {
+  description = "StorageClass to use for workloads in the Kubernetes model."
+  type        = string
+  default     = "microk8s-hostpath"
 }
 
 output "machine_model_uuid" {

--- a/terraform/product/tests/setup/main.tf
+++ b/terraform/product/tests/setup/main.tf
@@ -1,0 +1,40 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+terraform {
+  required_version = "~> 1.12"
+  required_providers {
+    juju = {
+      version = "~> 1.0"
+      source  = "juju/juju"
+    }
+  }
+}
+
+provider "juju" {}
+
+resource "juju_model" "machine" {
+  name = "tf-testing-deps-${formatdate("YYYYMMDDhhmmss", timestamp())}"
+}
+
+resource "juju_model" "k8s" {
+  name = "tf-testing-dh-${formatdate("YYYYMMDDhhmmss", timestamp())}"
+
+  cloud {
+    name = var.k8s_cloud_name
+  }
+}
+
+variable "k8s_cloud_name" {
+  description = "Name of the Kubernetes cloud registered on the controller."
+  type        = string
+  default     = "microk8s"
+}
+
+output "machine_model_uuid" {
+  value = juju_model.machine.uuid
+}
+
+output "k8s_model_uuid" {
+  value = juju_model.k8s.uuid
+}

--- a/terraform/product/tests/setup/main.tf
+++ b/terraform/product/tests/setup/main.tf
@@ -2,10 +2,10 @@
 # See LICENSE file for licensing details.
 
 terraform {
-  required_version = "~> 1.12"
+  required_version = "~> 1.14"
   required_providers {
     juju = {
-      version = "~> 1.0"
+      version = "~> 2.0"
       source  = "juju/juju"
     }
   }

--- a/terraform/product/tests/setup/main.tf
+++ b/terraform/product/tests/setup/main.tf
@@ -24,10 +24,6 @@ resource "juju_model" "k8s" {
   cloud {
     name = var.k8s_cloud_name
   }
-
-  config = {
-    workload-storage = var.workload_storage_class
-  }
 }
 
 variable "k8s_cloud_name" {
@@ -40,12 +36,6 @@ variable "k8s_credential_name" {
   description = "Name of the credential for the Kubernetes cloud."
   type        = string
   default     = "tfk8s"
-}
-
-variable "workload_storage_class" {
-  description = "StorageClass to use for workloads in the Kubernetes model."
-  type        = string
-  default     = "tfk8s-hostpath"
 }
 
 output "machine_model_uuid" {

--- a/terraform/product/tests/setup/main.tf
+++ b/terraform/product/tests/setup/main.tf
@@ -33,19 +33,19 @@ resource "juju_model" "k8s" {
 variable "k8s_cloud_name" {
   description = "Name of the Kubernetes cloud registered on the controller."
   type        = string
-  default     = "microk8s"
+  default     = "tfk8s"
 }
 
 variable "k8s_credential_name" {
   description = "Name of the credential for the Kubernetes cloud."
   type        = string
-  default     = "microk8s"
+  default     = "tfk8s"
 }
 
 variable "workload_storage_class" {
   description = "StorageClass to use for workloads in the Kubernetes model."
   type        = string
-  default     = "microk8s-hostpath"
+  default     = "tfk8s-hostpath"
 }
 
 output "machine_model_uuid" {

--- a/terraform/product/tests/setup/pre_run_script.sh
+++ b/terraform/product/tests/setup/pre_run_script.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+#
+# Pre-run setup for the product Terraform test. Sets the kernel sysctls OpenSearch requires so its
+# units reach `active` on the LXD machine cloud. LXD containers inherit these from the runner host.
+set -euo pipefail
+
+echo "vm.max_map_count=262144
+vm.swappiness=0
+net.ipv4.tcp_retries2=5
+fs.file-max=1048576" | sudo tee /etc/sysctl.d/99-charm-dev.conf
+
+sudo sysctl --system

--- a/terraform/product/tests/wait_for_active/main.tf
+++ b/terraform/product/tests/wait_for_active/main.tf
@@ -2,14 +2,14 @@
 # See LICENSE file for licensing details.
 
 terraform {
-  required_version = "~> 1.12"
+  required_version = "~> 1.14"
   required_providers {
     external = {
       version = "> 2"
       source  = "hashicorp/external"
     }
     juju = {
-      version = "~> 1.0"
+      version = "~> 2.0"
       source  = "juju/juju"
     }
   }

--- a/terraform/product/tests/wait_for_active/main.tf
+++ b/terraform/product/tests/wait_for_active/main.tf
@@ -1,0 +1,35 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+terraform {
+  required_version = "~> 1.12"
+  required_providers {
+    external = {
+      version = "> 2"
+      source  = "hashicorp/external"
+    }
+    juju = {
+      version = "~> 1.0"
+      source  = "juju/juju"
+    }
+  }
+}
+
+provider "juju" {}
+
+variable "model_uuid" {
+  type = string
+}
+
+variable "app_name" {
+  type = string
+}
+
+variable "timeout" {
+  type = number
+}
+
+# tflint-ignore: terraform_unused_declarations
+data "external" "app_status" {
+  program = ["bash", "${path.module}/wait-for-active.sh", var.model_uuid, var.app_name, var.timeout]
+}

--- a/terraform/product/tests/wait_for_active/wait-for-active.sh
+++ b/terraform/product/tests/wait_for_active/wait-for-active.sh
@@ -1,36 +1,36 @@
 #!/bin/bash
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
+#
+# Polls `juju status` until APP_NAME's application status is "active" (or "error", or until TIMEOUT
+# seconds elapse), then prints {"status": "<status>"} for the Terraform external data source.
 
 MODEL_UUID=$1
 APP_NAME=$2
 TIMEOUT=$3
 
 export APP_NAME
-
 LOG="/tmp/wait-for-active.$$.log"
 
 if [ -z "$MODEL_UUID" ] || [ -z "$APP_NAME" ] || [ -z "$TIMEOUT" ]; then
-	echo "Usage: $0 <model_uuid|model_name> <app_name> <timeout in seconds>"
-	echo "[$(date)] missing arguments" >>"$LOG"
-	exit 1
+	echo '{"status": "bad_arguments"}'
+	exit 0
 fi
 
-if ! juju show-model "$MODEL_UUID" &>/dev/null; then
-	echo '{"status": "model_not_found"}'
-	echo "[$(date)] model not found: $MODEL_UUID" >>"$LOG"
-	exit
-fi
+current_status() {
+	juju status "$APP_NAME" --model "$MODEL_UUID" --format=json 2>>"$LOG" |
+		jq -r '.applications[env.APP_NAME]["application-status"].current // "unknown"'
+}
 
-if ! juju show-application "$APP_NAME" --model "$MODEL_UUID" &>/dev/null; then
-	echo '{"status": "app_not_found"}'
-	echo "[$(date)] app not found: $APP_NAME" >>"$LOG"
-	exit
-fi
+deadline=$(($(date +%s) + TIMEOUT))
+status="unknown"
+while [ "$(date +%s)" -lt "$deadline" ]; do
+	status=$(current_status)
+	echo "[$(date)] $APP_NAME: $status" >>"$LOG"
+	case "$status" in
+	active | error) break ;;
+	esac
+	sleep 20
+done
 
-echo "[$(date)] waiting for $APP_NAME in $MODEL_UUID to be active" >>"$LOG"
-
-juju wait-for application "$APP_NAME" --timeout="${TIMEOUT}s" --model "$MODEL_UUID" &>>"$LOG"
-STATUS=$(juju status "$APP_NAME" --model "$MODEL_UUID" --format=json | jq -r '.applications[env.APP_NAME]["application-status"].current')
-
-echo '{"status": "'"$STATUS"'"}'
+echo '{"status": "'"$status"'"}'

--- a/terraform/product/tests/wait_for_active/wait-for-active.sh
+++ b/terraform/product/tests/wait_for_active/wait-for-active.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+MODEL_UUID=$1
+APP_NAME=$2
+TIMEOUT=$3
+
+export APP_NAME
+
+LOG="/tmp/wait-for-active.$$.log"
+
+if [ -z "$MODEL_UUID" ] || [ -z "$APP_NAME" ] || [ -z "$TIMEOUT" ]; then
+	echo "Usage: $0 <model_uuid|model_name> <app_name> <timeout in seconds>"
+	echo "[$(date)] missing arguments" >>"$LOG"
+	exit 1
+fi
+
+if ! juju show-model "$MODEL_UUID" &>/dev/null; then
+	echo '{"status": "model_not_found"}'
+	echo "[$(date)] model not found: $MODEL_UUID" >>"$LOG"
+	exit
+fi
+
+if ! juju show-application "$APP_NAME" --model "$MODEL_UUID" &>/dev/null; then
+	echo '{"status": "app_not_found"}'
+	echo "[$(date)] app not found: $APP_NAME" >>"$LOG"
+	exit
+fi
+
+echo "[$(date)] waiting for $APP_NAME in $MODEL_UUID to be active" >>"$LOG"
+
+juju wait-for application "$APP_NAME" --timeout="${TIMEOUT}s" --model "$MODEL_UUID" &>>"$LOG"
+STATUS=$(juju status "$APP_NAME" --model "$MODEL_UUID" --format=json | jq -r '.applications[env.APP_NAME]["application-status"].current')
+
+echo '{"status": "'"$STATUS"'"}'

--- a/terraform/product/variables.tf
+++ b/terraform/product/variables.tf
@@ -1,4 +1,4 @@
-# Copyright 2026 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 variable "database_offer_url" {

--- a/terraform/product/variables.tf
+++ b/terraform/product/variables.tf
@@ -55,13 +55,14 @@ variable "k8s_model_uuid" {
 variable "kafka" {
   description = "Configuration for the in-module Kafka charm (used when kafka_offer_url is empty)."
   type = object({
-    app_name    = optional(string, "kafka")
-    channel     = optional(string, "3/stable")
-    revision    = optional(number)
-    base        = optional(string, "ubuntu@22.04")
-    constraints = optional(string, "arch=amd64")
-    config      = optional(map(string), {})
-    units       = optional(number, 1)
+    app_name           = optional(string, "kafka")
+    channel            = optional(string, "3/stable")
+    revision           = optional(number)
+    base               = optional(string, "ubuntu@22.04")
+    constraints        = optional(string, "arch=amd64")
+    config             = optional(map(string), {})
+    storage_directives = optional(map(string), {})
+    units              = optional(number, 1)
   })
   default = {}
 }
@@ -96,13 +97,14 @@ variable "oidc" {
 variable "opensearch" {
   description = "Configuration for the in-module OpenSearch charm (used when opensearch_offer_url is empty)."
   type = object({
-    app_name    = optional(string, "opensearch")
-    channel     = optional(string, "2/stable")
-    revision    = optional(number)
-    base        = optional(string, "ubuntu@22.04")
-    constraints = optional(string, "arch=amd64")
-    config      = optional(map(string), {})
-    units       = optional(number, 2)
+    app_name           = optional(string, "opensearch")
+    channel            = optional(string, "2/stable")
+    revision           = optional(number)
+    base               = optional(string, "ubuntu@22.04")
+    constraints        = optional(string, "arch=amd64")
+    config             = optional(map(string), {})
+    storage_directives = optional(map(string), {})
+    units              = optional(number, 2)
   })
   default = {}
 }
@@ -116,13 +118,14 @@ variable "opensearch_offer_url" {
 variable "postgresql" {
   description = "Configuration for the in-module PostgreSQL charm (used when database_offer_url is empty)."
   type = object({
-    app_name    = optional(string, "postgresql")
-    channel     = optional(string, "14/stable")
-    revision    = optional(number)
-    base        = optional(string, "ubuntu@22.04")
-    constraints = optional(string, "arch=amd64")
-    config      = optional(map(string), {})
-    units       = optional(number, 1)
+    app_name           = optional(string, "postgresql")
+    channel            = optional(string, "14/stable")
+    revision           = optional(number)
+    base               = optional(string, "ubuntu@22.04")
+    constraints        = optional(string, "arch=amd64")
+    config             = optional(map(string), {})
+    storage_directives = optional(map(string), {})
+    units              = optional(number, 1)
   })
   default = {}
 }
@@ -168,13 +171,14 @@ variable "traefik_gms" {
 variable "zookeeper" {
   description = "Configuration for the in-module ZooKeeper charm (backend for Kafka; used when kafka_offer_url is empty)."
   type = object({
-    app_name    = optional(string, "zookeeper")
-    channel     = optional(string, "3/stable")
-    revision    = optional(number)
-    base        = optional(string, "ubuntu@22.04")
-    constraints = optional(string, "arch=amd64")
-    config      = optional(map(string), {})
-    units       = optional(number, 1)
+    app_name           = optional(string, "zookeeper")
+    channel            = optional(string, "3/stable")
+    revision           = optional(number)
+    base               = optional(string, "ubuntu@22.04")
+    constraints        = optional(string, "arch=amd64")
+    config             = optional(map(string), {})
+    storage_directives = optional(map(string), {})
+    units              = optional(number, 1)
   })
   default = {}
 }

--- a/terraform/product/variables.tf
+++ b/terraform/product/variables.tf
@@ -1,0 +1,180 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+variable "database_offer_url" {
+  description = <<-EOT
+    Offer URL for an external PostgreSQL `database` endpoint. Leave empty to deploy PostgreSQL
+    in-module (local, single-controller). Set together with kafka_offer_url and
+    opensearch_offer_url for the prod two-controller split (data platform deployed separately).
+  EOT
+  type        = string
+  default     = ""
+
+  validation {
+    condition = (
+      (var.database_offer_url == "" && var.kafka_offer_url == "" && var.opensearch_offer_url == "") ||
+      (var.database_offer_url != "" && var.kafka_offer_url != "" && var.opensearch_offer_url != "")
+    )
+    error_message = "Set all of database_offer_url, kafka_offer_url and opensearch_offer_url (external data platform), or none (deploy the data platform in-module)."
+  }
+}
+
+variable "datahub" {
+  description = "Configuration for the datahub-k8s charm."
+  type = object({
+    app_name    = optional(string, "datahub-k8s")
+    channel     = optional(string, "latest/edge")
+    revision    = optional(number)
+    base        = optional(string, "ubuntu@22.04")
+    constraints = optional(string)
+    config      = optional(map(string), {})
+    resources   = optional(map(string), {})
+    units       = optional(number, 1)
+  })
+  default = {}
+}
+
+variable "encryption_keys" {
+  description = <<-EOT
+    Optional overrides for the DataHub encryption keys. When a field is empty a random value is
+    generated. These are internal encryption keys, not credentials. Leave empty unless matching
+    an existing deployment.
+  EOT
+  type = object({
+    gms_key      = optional(string, "")
+    frontend_key = optional(string, "")
+  })
+  default = {}
+}
+
+variable "k8s_model_uuid" {
+  description = "UUID of the Kubernetes Juju model where DataHub and the ingress are deployed."
+  type        = string
+}
+
+variable "kafka" {
+  description = "Configuration for the in-module Kafka charm (used when kafka_offer_url is empty)."
+  type = object({
+    app_name    = optional(string, "kafka")
+    channel     = optional(string, "3/stable")
+    revision    = optional(number)
+    base        = optional(string, "ubuntu@22.04")
+    constraints = optional(string, "arch=amd64")
+    config      = optional(map(string), {})
+    units       = optional(number, 1)
+  })
+  default = {}
+}
+
+variable "kafka_offer_url" {
+  description = "Offer URL for an external Kafka `kafka-client` endpoint. See database_offer_url."
+  type        = string
+  default     = ""
+}
+
+variable "machine_model_uuid" {
+  description = "UUID of the machine Juju model for the in-module data platform. Required when the *_offer_url inputs are empty."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.database_offer_url != "" || var.machine_model_uuid != ""
+    error_message = "machine_model_uuid is required when deploying the in-module data platform (i.e. when the *_offer_url inputs are empty)."
+  }
+}
+
+variable "oidc" {
+  description = "OIDC client credentials for SSO. When set, a Juju secret is created and granted to DataHub. Leave null to disable SSO."
+  type = object({
+    client_id     = string
+    client_secret = string
+  })
+  default   = null
+  sensitive = true
+}
+
+variable "opensearch" {
+  description = "Configuration for the in-module OpenSearch charm (used when opensearch_offer_url is empty)."
+  type = object({
+    app_name    = optional(string, "opensearch")
+    channel     = optional(string, "2/stable")
+    revision    = optional(number)
+    base        = optional(string, "ubuntu@22.04")
+    constraints = optional(string, "arch=amd64")
+    config      = optional(map(string), {})
+    units       = optional(number, 2)
+  })
+  default = {}
+}
+
+variable "opensearch_offer_url" {
+  description = "Offer URL for an external OpenSearch `opensearch-client` endpoint. See database_offer_url."
+  type        = string
+  default     = ""
+}
+
+variable "postgresql" {
+  description = "Configuration for the in-module PostgreSQL charm (used when database_offer_url is empty)."
+  type = object({
+    app_name    = optional(string, "postgresql")
+    channel     = optional(string, "14/stable")
+    revision    = optional(number)
+    base        = optional(string, "ubuntu@22.04")
+    constraints = optional(string, "arch=amd64")
+    config      = optional(map(string), {})
+    units       = optional(number, 1)
+  })
+  default = {}
+}
+
+variable "self_signed_certificates" {
+  description = "Configuration for the self-signed-certificates charm (TLS for OpenSearch and the Traefik ingresses)."
+  type = object({
+    app_name    = optional(string, "self-signed-certificates")
+    channel     = optional(string, "latest/stable")
+    revision    = optional(number)
+    base        = optional(string, "ubuntu@22.04")
+    constraints = optional(string, "arch=amd64")
+    config      = optional(map(string), {})
+    units       = optional(number, 1)
+  })
+  default = {}
+}
+
+variable "traefik_frontend" {
+  description = "Configuration for the Traefik ingress in front of the DataHub frontend."
+  type = object({
+    app_name = optional(string, "traefik-frontend")
+    channel  = optional(string, "latest/stable")
+    revision = optional(number)
+    config   = optional(map(string), {})
+    units    = optional(number, 1)
+  })
+  default = {}
+}
+
+variable "traefik_gms" {
+  description = "Configuration for the Traefik ingress in front of DataHub GMS."
+  type = object({
+    app_name = optional(string, "traefik-gms")
+    channel  = optional(string, "latest/stable")
+    revision = optional(number)
+    config   = optional(map(string), {})
+    units    = optional(number, 1)
+  })
+  default = {}
+}
+
+variable "zookeeper" {
+  description = "Configuration for the in-module ZooKeeper charm (backend for Kafka; used when kafka_offer_url is empty)."
+  type = object({
+    app_name    = optional(string, "zookeeper")
+    channel     = optional(string, "3/stable")
+    revision    = optional(number)
+    base        = optional(string, "ubuntu@22.04")
+    constraints = optional(string, "arch=amd64")
+    config      = optional(map(string), {})
+    units       = optional(number, 1)
+  })
+  default = {}
+}


### PR DESCRIPTION
This PR adds two terraform modules for deploying DataHub independently or together with its full dependency stack and a git workflow that leverages `operator-workflows` for testing them.