### PR TITLE
fix: health check

### DIFF
--- a/datahub_rocks/gms/rockcraft.yaml
+++ b/datahub_rocks/gms/rockcraft.yaml
@@ -33,7 +33,7 @@ checks:
     override: merge
     threshold: 4
     http:
-      url: "http://localhost:8080/health"
+      url: "http://localhost:8080/health/live"
 
 parts:
   # ---- Metadata ----

--- a/src/services.py
+++ b/src/services.py
@@ -548,7 +548,7 @@ class GMSService(AbstractService):
     name = "datahub-gms"
     command = "/datahub/datahub-gms/scripts/start.sh"
     healthcheck = {
-        "endpoint": "/health",
+        "endpoint": "/health/live",
         "port": "8080",
     }
 


### PR DESCRIPTION
This PR fixes the health check that has been causing the charm to report `status check: DOWN` even if the GMS was up and running. After v1.4 the liveness health check is under `/health/live`.