### PR TITLE
feat: datahub_client interface

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,6 +141,10 @@ make test-integration  # Runs integration tests*
 
 *: It is recommended to let CI runners run integration tests on GitHub Actions.
 
+## Charm libraries owned by this repository
+
+[`lib/charms/datahub_k8s/v0/datahub_client.py`](lib/charms/datahub_k8s/v0/datahub_client.py) defines both sides of the `datahub_client` interface. Requirer charms carry a copy, so after changing it, bump `LIBPATCH`, publish it, and update the requirers if needed.
+
 ## Deploying locally
 
 ### Multipass environment setup
@@ -308,7 +312,11 @@ juju integrate datahub-k8s os-client
 
 **Note:** It is highly recommended to wait between commands to let `juju status` show an `active-idle` status for the charm.
 
-After the final command, it will take some time for the `datahub-frontend` container to settle. Once it does, you can login on `localhost:9002` with `datahub` for the username and the password fetched as described in the [README](./README.md#deploying-datahub). Refer to [below](#accessing-datahub-from-the-host-machine) on how to connect to a `datahub` deployment inside a `multipass` VM.
+After the final command, it will take some time for the `datahub-frontend` container to settle. Once it does, you can login on port `9002` of the unit address with `datahub` for the username and the password fetched with:
+
+```shell
+juju run datahub-k8s/0 get-password
+```
 
 **Note:** If the Opensearch offer is blocked from the provider end, DataHub will load but some functionalities such as `Ingestion` will not load. This is best identified by the requests to `/graphql` returning a `500`.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Full documentation for this charm (tutorial, how-to guides, reference, and expla
 
 ## Description
 
-DataHub is an extensible data catalog that enables data discovery, data observability and federated data governance.
+DataHub is an extensible data catalog that enables data discovery, data observability and federated data governance. It is a component of the Canonical Data Mesh solution.
 
 ### Architecture
 
@@ -50,14 +50,14 @@ juju deploy postgresql
 juju deploy kafka
 juju deploy zookeeper
 juju deploy opensearch --channel 2/edge -n 2
-juju deploy self-signed-certificates-operator
+juju deploy self-signed-certificates
 
 # Wait for the units to settle
 juju status --watch 3s --color
 
 # Relate
 juju relate kafka zookeeper
-juju relate opensearch self-signed-certificates-operator
+juju relate opensearch self-signed-certificates
 
 # Create named offers
 juju offer postgresql:database pg-client
@@ -273,6 +273,16 @@ The charm creates the following resources in DataHub, identifiable by their nami
 
 When a catalog is removed or the Trino relation is broken, the corresponding ingestion sources and secrets are automatically deleted. User-created secrets and ingestion sources are not affected if they do not match the charm conventions.
 
+### Serving the API to other charms
+
+The `datahub-client` endpoint (interface `datahub_client`) lets another charm consume the GMS API without anyone handling a token by hand. On integration, DataHub creates a **service account** dedicated to that relation, mints a Personal Access Token for it, stores the token in a Juju secret granted to the relation, and publishes the GMS URL and the secret ID:
+
+```sh
+juju integrate datahub-k8s datahub-mcp-k8s
+```
+
+The service account gets no privileges of its own, so it inherits DataHub's default all-users policies of metadata read, no writes. Grant it a policy in DataHub if a consumer needs more. Removing the relation deletes the service account, which invalidates every token issued for it.
+
 ### Troubleshooting
 
 - **Opensearch offer blocked**: If the Opensearch offer is blocked from the provider end, DataHub will load but some functionalities such as `Ingestion` will not work. This is best identified by requests to `/graphql` returning a `500` error. Ensure the offer is accepted on the provider side.
@@ -287,7 +297,9 @@ kubectl -n <namespace> exec -c datahub-gms datahub-k8s-0 -- cat /tmp/<log-file>
 ```
 
 ## Contributing
+
 This charm is still in active development. Please see the [Juju SDK docs](https://juju.is/docs/sdk) for guidelines on enhancements to this charm following best practice guidelines, and [CONTRIBUTING.md](CONTRIBUTING.md) for developer guidance.
 
 ## License
+
 The Charmed DataHub K8s Operator is free software, distributed under the Apache Software License, version 2.0. See [License](LICENSE) for more details.

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -89,6 +89,10 @@ peers:
     interface: datahub
 
 provides:
+  datahub-client:
+    interface: datahub_client
+    optional: true
+
   metrics-endpoint:
     interface: prometheus_scrape
     optional: true

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -65,6 +65,8 @@ charm-libs:
     version: "0"
   - lib: loki_k8s.loki_push_api
     version: "1"
+  - lib: datahub_k8s.datahub_client
+    version: "0"
 
 parts:
   charm:

--- a/lib/charms/datahub_k8s/v0/datahub_client.py
+++ b/lib/charms/datahub_k8s/v0/datahub_client.py
@@ -1,0 +1,193 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Library for the datahub_client relation.
+
+This library provides the DatahubClientProvider and DatahubClientRequirer classes that
+handle the provider and the requirer sides of the datahub_client interface.
+
+The interface lets a charm consume the DataHub GMS API as a dedicated DataHub service
+account. The provider (datahub-k8s) creates the service account, mints a Personal
+Access Token for it, stores the token in a Juju secret granted to the relation, and
+publishes the GMS URL alongside the secret ID. The requirer reads both and configures
+its workload.
+
+Provider application databag:
+
+    gms-url               URL of the GMS API, reachable from the requirer.
+    secret-id             ID of a Juju secret whose `token` key holds the PAT.
+    service-account-urn   URN of the DataHub service account the token acts as.
+"""
+
+import logging
+from dataclasses import dataclass
+from typing import Optional
+
+from ops.charm import CharmBase
+from ops.framework import Object
+from ops.model import ModelError, Relation, SecretNotFoundError
+
+# The unique Charmhub library identifier, never change it
+LIBID = "4ff63aa2b2d343dda41ef50d08be8414"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_RELATION_NAME = "datahub-client"
+
+GMS_URL_FIELD = "gms-url"
+SECRET_ID_FIELD = "secret-id"  # nosec B105
+SERVICE_ACCOUNT_URN_FIELD = "service-account-urn"
+TOKEN_SECRET_KEY = "token"  # nosec B105
+
+
+@dataclass(frozen=True)
+class DatahubConnection:
+    """Everything a requirer needs to talk to DataHub GMS.
+
+    Attributes:
+        gms_url: URL of the GMS API.
+        token: DataHub Personal Access Token to authenticate with.
+        service_account_urn: URN of the service account the token acts as.
+    """
+
+    gms_url: str
+    token: str
+    service_account_urn: str
+
+
+class DatahubClientProvider(Object):
+    """Provider side of the datahub_client relation.
+
+    The library owns the databag layout; the charm owns the DataHub-side
+    resources (service account, access token) and the Juju secret.
+    """
+
+    def __init__(self, charm: CharmBase, relation_name: str = DEFAULT_RELATION_NAME):
+        """Construct.
+
+        Args:
+            charm: The charm instance.
+            relation_name: Name of the relation.
+        """
+        super().__init__(charm, relation_name)
+        self.charm = charm
+        self.relation_name = relation_name
+
+    def get_service_account_urn(self, relation: Relation) -> Optional[str]:
+        """Return the service account URN previously published on a relation.
+
+        Args:
+            relation: The relation to read.
+
+        Returns:
+            The URN, or None if nothing has been published yet.
+        """
+        return relation.data[self.charm.app].get(SERVICE_ACCOUNT_URN_FIELD) or None
+
+    def get_secret_id(self, relation: Relation) -> Optional[str]:
+        """Return the token secret ID previously published on a relation.
+
+        Args:
+            relation: The relation to read.
+
+        Returns:
+            The Juju secret ID, or None if nothing has been published yet.
+        """
+        return relation.data[self.charm.app].get(SECRET_ID_FIELD) or None
+
+    def publish_connection(
+        self,
+        relation: Relation,
+        gms_url: str,
+        secret_id: str,
+        service_account_urn: str,
+    ) -> None:
+        """Publish the connection details on a relation.
+
+        Args:
+            relation: The relation to update.
+            gms_url: URL of the GMS API reachable from the requirer.
+            secret_id: ID of the Juju secret holding the access token.
+            service_account_urn: URN of the DataHub service account.
+        """
+        if not self.charm.unit.is_leader():
+            return
+
+        relation.data[self.charm.app].update(
+            {
+                GMS_URL_FIELD: gms_url,
+                SECRET_ID_FIELD: secret_id,
+                SERVICE_ACCOUNT_URN_FIELD: service_account_urn,
+            }
+        )
+        logger.info("Published datahub-client connection on relation %s", relation.id)
+
+
+class DatahubClientRequirer(Object):
+    """Requirer side of the datahub_client relation."""
+
+    def __init__(self, charm: CharmBase, relation_name: str = DEFAULT_RELATION_NAME):
+        """Construct.
+
+        Args:
+            charm: The charm instance.
+            relation_name: Name of the relation.
+        """
+        super().__init__(charm, relation_name)
+        self.charm = charm
+        self.relation_name = relation_name
+
+    @property
+    def is_related(self) -> bool:
+        """Return whether the relation currently exists."""
+        return bool(self.charm.model.relations.get(self.relation_name))
+
+    def get_connection(self) -> Optional[DatahubConnection]:
+        """Return the current DataHub connection details.
+
+        Returns:
+            A DatahubConnection, or None while the provider has not published
+            complete details or the token secret is not readable yet.
+        """
+        relations = self.charm.model.relations.get(self.relation_name, [])
+        if not relations:
+            return None
+
+        relation = relations[0]
+        if not relation.app:
+            return None
+
+        data = relation.data[relation.app]
+        gms_url = data.get(GMS_URL_FIELD)
+        secret_id = data.get(SECRET_ID_FIELD)
+        service_account_urn = data.get(SERVICE_ACCOUNT_URN_FIELD)
+        if not all([gms_url, secret_id, service_account_urn]):
+            logger.debug("datahub-client relation data is incomplete")
+            return None
+
+        try:
+            secret = self.charm.model.get_secret(id=secret_id)
+            token = secret.get_content(refresh=True).get(TOKEN_SECRET_KEY)
+        except SecretNotFoundError:
+            logger.info("datahub-client token secret '%s' not found yet", secret_id)
+            return None
+        except ModelError as e:
+            logger.info("datahub-client token secret '%s' is not readable yet: %s", secret_id, e)
+            return None
+
+        if not token:
+            logger.warning("datahub-client token secret '%s' has no '%s' key", secret_id, TOKEN_SECRET_KEY)
+            return None
+
+        return DatahubConnection(
+            gms_url=str(gms_url),
+            token=token,
+            service_account_urn=str(service_account_urn),
+        )

--- a/lib/charms/datahub_k8s/v0/datahub_client.py
+++ b/lib/charms/datahub_k8s/v0/datahub_client.py
@@ -28,7 +28,7 @@ from ops.framework import Object
 from ops.model import ModelError, Relation, SecretNotFoundError
 
 # The unique Charmhub library identifier, never change it
-LIBID = "4ff63aa2b2d343dda41ef50d08be8414"
+LIBID = "e20436709cfa48f289bf37c08b53b482"
 
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0

--- a/src/charm.py
+++ b/src/charm.py
@@ -28,6 +28,7 @@ import literals
 import services
 import utils
 from log import log_event_handler
+from relations.datahub_client import DatahubClientRelation
 from relations.kafka import KafkaRelation
 from relations.oauth import OauthRelation
 from relations.opensearch import OpenSearchRelation
@@ -148,6 +149,9 @@ class DatahubK8SOperatorCharm(TypedCharmBase[CharmConfig]):
 
         # OAuth (SSO via the Canonical Identity Platform or an external IdP integrator)
         self.oauth_relation = OauthRelation(self)
+
+        # DataHub API clients (e.g. the MCP server) served a per-relation service account
+        self.datahub_client_relation = DatahubClientRelation(self)
 
         # Ingress. `strip_prefix=True` so Traefik strips the per-app path
         # prefix before forwarding, the frontend SPA and GMS REST endpoints
@@ -370,6 +374,17 @@ class DatahubK8SOperatorCharm(TypedCharmBase[CharmConfig]):
         except Exception as e:
             logger.error("Trino reconciliation failed: %s", str(e))
 
+    def _reconcile_datahub_clients_if_ready(self):
+        """Provision DataHub API clients if preconditions are met."""
+        if not self.unit.is_leader():
+            return
+        if not self.model.get_relation(literals.DATAHUB_CLIENT_RELATION_NAME):
+            return
+        try:
+            self.datahub_client_relation.reconcile_clients()
+        except Exception as e:
+            logger.error("DataHub client reconciliation failed: %s", str(e))
+
     def _check_state(self):  # noqa: C901
         """Check the current state of the relations and overall charm readiness.
 
@@ -550,6 +565,7 @@ class DatahubK8SOperatorCharm(TypedCharmBase[CharmConfig]):
                 return
 
         self._reconcile_trino_if_ready()
+        self._reconcile_datahub_clients_if_ready()
 
         self.unit.status = ops.ActiveStatus()
 

--- a/src/graphql.py
+++ b/src/graphql.py
@@ -61,14 +61,21 @@ def _graphql_request(
     return body
 
 
-def create_access_token(system_client_id: str, system_client_secret: str) -> str:
-    """Create a DataHub access token for the system user.
+def create_access_token(
+    system_client_id: str,
+    system_client_secret: str,
+    actor_urn: str = f"urn:li:corpuser:{literals.SYSTEM_CLIENT_ID}",
+    name: str = "juju-managed-ingestion-token",
+) -> str:
+    """Create a DataHub access token for an actor.
 
     Uses Basic auth with system client credentials to bootstrap a token.
 
     Args:
         system_client_id: DataHub system client identifier.
         system_client_secret: DataHub system client secret.
+        actor_urn: URN of the actor the token authenticates as.
+        name: Human-readable name shown in the DataHub token list.
 
     Returns:
         The generated access token string.
@@ -82,14 +89,102 @@ def create_access_token(system_client_id: str, system_client_secret: str) -> str
     variables = {
         "input": {
             "type": "PERSONAL",
-            "actorUrn": f"urn:li:corpuser:{literals.SYSTEM_CLIENT_ID}",
+            "actorUrn": actor_urn,
             "duration": "NO_EXPIRY",
-            "name": "juju-managed-ingestion-token",
+            "name": name,
         }
     }
     basic_credentials = f"{system_client_id}:{system_client_secret}"
     body = _graphql_request(query, variables, basic_credentials, auth_scheme="Basic")
     return body["data"]["createAccessToken"]["accessToken"]
+
+
+def list_service_accounts(system_client_id: str, system_client_secret: str) -> Dict[str, str]:
+    """List DataHub service accounts, returning a URN-to-display-name mapping.
+
+    Args:
+        system_client_id: DataHub system client identifier.
+        system_client_secret: DataHub system client secret.
+
+    Returns:
+        Dictionary mapping service account URNs to their display names.
+    """
+    query = textwrap.dedent("""\
+        query listServiceAccounts($input: ListServiceAccountsInput!) {
+            listServiceAccounts(input: $input) {
+                total
+                serviceAccounts {
+                    urn
+                    displayName
+                }
+            }
+        }""")
+    basic_credentials = f"{system_client_id}:{system_client_secret}"
+    start = 0
+    count = 100
+    accounts: Dict[str, str] = {}
+
+    while True:
+        prev_size = len(accounts)
+        variables = {"input": {"start": start, "count": count}}
+        body = _graphql_request(query, variables, basic_credentials, auth_scheme="Basic")
+        data = body["data"]["listServiceAccounts"]
+        for account in data.get("serviceAccounts", []):
+            accounts[account["urn"]] = account.get("displayName") or ""
+        if len(accounts) >= data["total"] or len(accounts) == prev_size:
+            break
+        start += count
+
+    return accounts
+
+
+def create_service_account(
+    system_client_id: str,
+    system_client_secret: str,
+    display_name: str,
+    description: str,
+) -> str:
+    """Create a DataHub service account.
+
+    DataHub assigns the URN; it cannot be chosen by the caller.
+
+    Args:
+        system_client_id: DataHub system client identifier.
+        system_client_secret: DataHub system client secret.
+        display_name: Display name for the service account.
+        description: Description shown in the DataHub UI.
+
+    Returns:
+        URN of the newly created service account.
+    """
+    query = textwrap.dedent("""\
+        mutation createServiceAccount($input: CreateServiceAccountInput!) {
+            createServiceAccount(input: $input) {
+                urn
+            }
+        }""")
+    variables = {"input": {"displayName": display_name, "description": description}}
+    basic_credentials = f"{system_client_id}:{system_client_secret}"
+    body = _graphql_request(query, variables, basic_credentials, auth_scheme="Basic")
+    return body["data"]["createServiceAccount"]["urn"]
+
+
+def delete_service_account(system_client_id: str, system_client_secret: str, urn: str) -> None:
+    """Delete a DataHub service account.
+
+    Deleting the account invalidates every access token issued for it.
+
+    Args:
+        system_client_id: DataHub system client identifier.
+        system_client_secret: DataHub system client secret.
+        urn: URN of the service account to delete.
+    """
+    query = textwrap.dedent("""\
+        mutation deleteServiceAccount($urn: String!) {
+            deleteServiceAccount(urn: $urn)
+        }""")
+    basic_credentials = f"{system_client_id}:{system_client_secret}"
+    _graphql_request(query, {"urn": urn}, basic_credentials, auth_scheme="Basic")
 
 
 def list_secrets(bearer_token: str) -> Dict[str, str]:

--- a/src/literals.py
+++ b/src/literals.py
@@ -31,6 +31,11 @@ SYSTEM_CLIENT_SECRET_LABEL = "datahub-system-client-secret"  # nosec B105
 INGESTION_TOKEN_SECRET_LABEL = "datahub-ingestion-token"  # nosec B105
 DEFAULT_EXECUTOR_ID = "default"
 
+# `datahub_client` relation: one DataHub service account and one Juju secret
+# holding its access token, per relation.
+DATAHUB_CLIENT_RELATION_NAME = "datahub-client"
+DATAHUB_CLIENT_SA_NAME_PREFIX = "[juju] "
+
 # Paths for scripts baked into the rocks (see datahub_rocks/shared/scripts/).
 RUNNER_PATH = "/charm-scripts/runner.sh"
 

--- a/src/relations/datahub_client.py
+++ b/src/relations/datahub_client.py
@@ -78,7 +78,7 @@ class DatahubClientRelation(framework.Object):
         ingress_url = self.charm.gms_ingress.url if self.charm.gms_ingress.is_ready() else None
         if ingress_url:
             return ingress_url.rstrip("/")
-        return f"http://{self.charm.app.name}.{self.charm.model.name}" f".svc.cluster.local:{literals.GMS_PORT}"
+        return f"http://{self.charm.app.name}.{self.charm.model.name}.svc.cluster.local:{literals.GMS_PORT}"
 
     @log_event_handler(logger)
     def _on_relation_changed(self, event) -> None:

--- a/src/relations/datahub_client.py
+++ b/src/relations/datahub_client.py
@@ -1,0 +1,249 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Define the DataHub-client relation, provisioning per-relation service accounts."""
+
+import logging
+import re
+from typing import Dict, Optional, Set, Tuple
+
+import ops
+from charms.datahub_k8s.v0.datahub_client import (  # pylint: disable=E0611
+    TOKEN_SECRET_KEY,
+    DatahubClientProvider,
+)
+from ops import framework
+
+import graphql
+import literals
+from log import log_event_handler
+
+logger = logging.getLogger(__name__)
+
+_MANAGED_NAME_PATTERN = re.compile(rf"^{re.escape(literals.DATAHUB_CLIENT_SA_NAME_PREFIX)}.+-(\d+)$")
+
+
+def _relation_id_from_name(display_name: str) -> Optional[int]:
+    """Return the relation ID encoded in a managed service account's name.
+
+    Args:
+        display_name: DataHub display name of the service account.
+
+    Returns:
+        The relation ID, or None when the account is not Juju-managed.
+    """
+    match = _MANAGED_NAME_PATTERN.match(display_name or "")
+    return int(match.group(1)) if match else None
+
+
+class DatahubClientRelation(framework.Object):
+    """Client for datahub:datahub-client relations.
+
+    Each relation gets its own DataHub service account and its own access
+    token. The token lives in an app-owned Juju secret granted to the relation,
+    so it is never written into a databag.
+
+    The service account holds no write privileges: it only inherits DataHub's
+    default all-users read policies, which is the least privilege a read-only
+    metadata consumer needs.
+
+    Attributes:
+        charm: The charm this relation is attached to.
+        provider: The DatahubClientProvider handling the relation databag.
+        gms_url: URL of the GMS API published to requirers.
+    """
+
+    def __init__(self, charm):
+        """Construct.
+
+        Args:
+            charm: The charm to attach the hooks to.
+        """
+        super().__init__(charm, literals.DATAHUB_CLIENT_RELATION_NAME)
+        self.charm = charm
+        self.provider = DatahubClientProvider(charm, relation_name=literals.DATAHUB_CLIENT_RELATION_NAME)
+
+        charm.framework.observe(
+            charm.on[literals.DATAHUB_CLIENT_RELATION_NAME].relation_changed,
+            self._on_relation_changed,
+        )
+        charm.framework.observe(
+            charm.on[literals.DATAHUB_CLIENT_RELATION_NAME].relation_broken,
+            self._on_relation_broken,
+        )
+
+    @property
+    def gms_url(self) -> str:
+        """Return the URL of the GMS API to publish to requirers."""
+        ingress_url = self.charm.gms_ingress.url if self.charm.gms_ingress.is_ready() else None
+        if ingress_url:
+            return ingress_url.rstrip("/")
+        return f"http://{self.charm.app.name}.{self.charm.model.name}" f".svc.cluster.local:{literals.GMS_PORT}"
+
+    @log_event_handler(logger)
+    def _on_relation_changed(self, event) -> None:
+        """Handle datahub-client relation changed events.
+
+        Args:
+            event: The event triggered when the relation changed.
+        """
+        self.charm.reconcile()
+
+    @log_event_handler(logger)
+    def _on_relation_broken(self, event) -> None:
+        """Delete the DataHub service account backing a departing relation.
+
+        Args:
+            event: The event triggered when the relation is broken.
+        """
+        if not self.charm.unit.is_leader():
+            return
+
+        urn = self.provider.get_service_account_urn(event.relation)
+        if urn:
+            try:
+                graphql.delete_service_account(self.charm.system_client_id, self.charm.system_client_secret, urn)
+                logger.info("Deleted DataHub service account '%s'", urn)
+            except Exception as e:  # pylint: disable=W0703
+                logger.error("Failed to delete DataHub service account '%s': %s", urn, str(e))
+
+        self._remove_secret(event.relation)
+        self.charm.reconcile()
+
+    def reconcile_clients(self) -> None:
+        """Ensure every datahub-client relation has a service account and a token."""
+        relations = self.charm.model.relations.get(literals.DATAHUB_CLIENT_RELATION_NAME, [])
+        existing = graphql.list_service_accounts(self.charm.system_client_id, self.charm.system_client_secret)
+
+        for relation in relations:
+            try:
+                urn, secret_id = self._ensure_credentials(relation, existing)
+            except Exception as e:  # pylint: disable=W0703
+                logger.error("Failed to provision datahub-client relation %s: %s", relation.id, str(e))
+                continue
+            self.provider.publish_connection(relation, self.gms_url, secret_id, urn)
+
+        self._delete_obsolete_accounts(existing, {relation.id for relation in relations})
+
+    def _delete_obsolete_accounts(self, existing: Dict[str, str], live_relation_ids: Set[int]) -> None:
+        """Delete service accounts left behind by relations that no longer exist.
+
+        `relation-broken` deletes eagerly, but it is a charm's last chance: if
+        GMS happens to be unreachable then, the account survives its relation.
+        Reconcile sweeps those up on the next pass.
+
+        Args:
+            existing: URN-to-display-name mapping of DataHub service accounts.
+            live_relation_ids: IDs of the relations that currently exist.
+        """
+        for urn, display_name in existing.items():
+            relation_id = _relation_id_from_name(display_name)
+            if relation_id is None or relation_id in live_relation_ids:
+                continue
+            try:
+                graphql.delete_service_account(self.charm.system_client_id, self.charm.system_client_secret, urn)
+                logger.info("Deleted obsolete DataHub service account '%s' (%s)", display_name, urn)
+            except Exception as e:  # pylint: disable=W0703
+                logger.error("Failed to delete obsolete service account '%s': %s", urn, str(e))
+
+    def _ensure_credentials(self, relation: ops.Relation, existing: Dict[str, str]) -> Tuple[str, str]:
+        """Return the service account URN and token secret ID for a relation.
+
+        Both are created on first call. The service account is checked against
+        DataHub rather than trusted from the databag, so an account deleted
+        out-of-band (or lost with a restored backend) is recreated together
+        with a fresh token.
+
+        Args:
+            relation: The relation to provision.
+            existing: URN-to-display-name mapping of DataHub service accounts.
+
+        Returns:
+            Tuple of (service account URN, Juju secret ID).
+        """
+        known_urn = self.provider.get_service_account_urn(relation)
+
+        if known_urn and known_urn in existing:
+            secret_id = self._get_secret_id(relation)
+            if secret_id:
+                return known_urn, secret_id
+            logger.info("Token secret for relation %s is missing, minting a new token", relation.id)
+            return known_urn, self._create_secret(relation, known_urn)
+
+        urn = graphql.create_service_account(
+            self.charm.system_client_id,
+            self.charm.system_client_secret,
+            self._service_account_name(relation),
+            f"Read-only DataHub service account managed by Juju for the "
+            f"'{relation.name}' relation with '{relation.app.name if relation.app else 'unknown'}'.",
+        )
+        logger.info("Created DataHub service account '%s' for relation %s", urn, relation.id)
+        # The previous secret, if any, holds a token for a service account that
+        # no longer exists.
+        self._remove_secret(relation)
+        return urn, self._create_secret(relation, urn)
+
+    def _service_account_name(self, relation: ops.Relation) -> str:
+        """Return the DataHub display name for a relation's service account.
+
+        Args:
+            relation: The relation the service account belongs to.
+
+        Returns:
+            A display name that is unique per relation.
+        """
+        app_name = relation.app.name if relation.app else literals.DATAHUB_CLIENT_RELATION_NAME
+        return f"{literals.DATAHUB_CLIENT_SA_NAME_PREFIX}{app_name}-{relation.id}"
+
+    def _get_secret_id(self, relation: ops.Relation) -> Optional[str]:
+        """Return the ID of a relation's live token secret, or None if absent.
+
+        Args:
+            relation: The relation to read.
+
+        Returns:
+            The Juju secret ID, or None when nothing usable is published.
+        """
+        secret_id = self.provider.get_secret_id(relation)
+        if not secret_id:
+            return None
+        try:
+            self.charm.model.get_secret(id=secret_id)
+        except ops.SecretNotFoundError:
+            return None
+        return secret_id
+
+    def _create_secret(self, relation: ops.Relation, service_account_urn: str) -> str:
+        """Mint an access token and store it in a Juju secret granted to a relation.
+
+        Args:
+            relation: The relation to grant the secret to.
+            service_account_urn: URN the token authenticates as.
+
+        Returns:
+            The Juju secret ID.
+        """
+        token = graphql.create_access_token(
+            self.charm.system_client_id,
+            self.charm.system_client_secret,
+            actor_urn=service_account_urn,
+            name=self._service_account_name(relation),
+        )
+        secret = self.charm.app.add_secret({TOKEN_SECRET_KEY: token})
+        secret.grant(relation)
+        logger.info("Created token secret for relation %s", relation.id)
+        return secret.id
+
+    def _remove_secret(self, relation: ops.Relation) -> None:
+        """Remove a relation's token secret if it exists.
+
+        Args:
+            relation: The relation whose secret should be removed.
+        """
+        secret_id = self.provider.get_secret_id(relation)
+        if not secret_id:
+            return
+        try:
+            self.charm.model.get_secret(id=secret_id).remove_all_revisions()
+        except ops.SecretNotFoundError:
+            logger.debug("No token secret to remove for relation %s", relation.id)

--- a/tests/unit/test_datahub_client.py
+++ b/tests/unit/test_datahub_client.py
@@ -1,0 +1,272 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Unit tests for the datahub-client relation provider."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import ops
+import pytest
+from charms.datahub_k8s.v0.datahub_client import (  # pylint: disable=E0611
+    DatahubClientRequirer,
+)
+
+import literals
+from relations.datahub_client import DatahubClientRelation
+
+SA_URN = "urn:li:corpuser:service_abc"
+OTHER_URN = "urn:li:corpuser:service_def"
+
+
+def _relation(relation_id=7, app_name="datahub-mcp-k8s"):
+    """Build a stub ops.Relation good enough for the provider."""
+    return SimpleNamespace(
+        id=relation_id,
+        name=literals.DATAHUB_CLIENT_RELATION_NAME,
+        app=SimpleNamespace(name=app_name),
+    )
+
+
+def _client_relation(
+    *,
+    known_urn=None,
+    published_secret_id="secret://existing",
+    secret_exists=True,
+    ingress_url=None,
+):
+    """Build a DatahubClientRelation bound to a MagicMock charm without running __init__."""
+    charm = MagicMock()
+    charm.app.name = "datahub-k8s"
+    charm.model.name = "datahub"
+    charm.gms_ingress.is_ready.return_value = ingress_url is not None
+    charm.gms_ingress.url = ingress_url
+    charm.system_client_id = "__datahub_system"
+    charm.system_client_secret = "sys-secret"  # nosec B105
+    charm.unit.is_leader.return_value = True
+
+    secret = MagicMock()
+    secret.id = "secret://minted"
+    charm.app.add_secret.return_value = secret
+    if secret_exists:
+        charm.model.get_secret.return_value = MagicMock(id=published_secret_id)
+    else:
+        charm.model.get_secret.side_effect = ops.SecretNotFoundError()
+
+    rel = DatahubClientRelation.__new__(DatahubClientRelation)
+    rel.charm = charm
+    rel.provider = MagicMock()
+    rel.provider.get_service_account_urn.return_value = known_urn
+    rel.provider.get_secret_id.return_value = published_secret_id
+    return rel
+
+
+CLUSTER_URL = f"http://datahub-k8s.datahub.svc.cluster.local:{literals.GMS_PORT}"
+
+
+class TestGmsUrl:
+    """Tests for the published GMS URL."""
+
+    def test_prefers_the_ingress_url(self):
+        """The ingress URL is reachable from other models, the Service name is not."""
+        rel = _client_relation(ingress_url="https://gms.example.com/datahub/")
+        assert rel.gms_url == "https://gms.example.com/datahub"
+
+    def test_falls_back_to_kubernetes_service_dns(self):
+        """Without an ingress, the Juju-created Service for the application is used."""
+        rel = _client_relation(ingress_url=None)
+        assert rel.gms_url == CLUSTER_URL
+
+
+class TestEnsureCredentials:
+    """Tests for the service account / token provisioning logic."""
+
+    def test_reuses_existing_account_and_secret(self):
+        """A live service account with a live secret triggers no DataHub writes."""
+        rel = _client_relation(known_urn=SA_URN)
+        with (
+            patch("graphql.create_service_account") as create_sa,
+            patch("graphql.create_access_token") as mint,
+        ):
+            urn, secret_id = rel._ensure_credentials(_relation(), {SA_URN: "[juju] x-7"})
+
+        assert (urn, secret_id) == (SA_URN, "secret://existing")
+        create_sa.assert_not_called()
+        mint.assert_not_called()
+
+    def test_creates_account_and_token_when_absent(self):
+        """Nothing published yet: create the service account and mint a token."""
+        rel = _client_relation(known_urn=None, published_secret_id=None, secret_exists=False)
+        with (
+            patch("graphql.create_service_account", return_value=SA_URN) as create_sa,
+            patch("graphql.create_access_token", return_value="pat") as mint,
+        ):
+            urn, secret_id = rel._ensure_credentials(_relation(), {})
+
+        assert (urn, secret_id) == (SA_URN, "secret://minted")
+        create_sa.assert_called_once()
+        assert create_sa.call_args.args[2] == "[juju] datahub-mcp-k8s-7"
+        assert mint.call_args.kwargs["actor_urn"] == SA_URN
+        rel.charm.app.add_secret.assert_called_once()
+        rel.charm.app.add_secret.return_value.grant.assert_called_once()
+
+    def test_recreates_when_service_account_vanished(self):
+        """A service account deleted out-of-band is recreated with a fresh token."""
+        rel = _client_relation(known_urn=SA_URN)
+        with (
+            patch("graphql.create_service_account", return_value=OTHER_URN) as create_sa,
+            patch("graphql.create_access_token", return_value="pat"),
+        ):
+            urn, secret_id = rel._ensure_credentials(_relation(), {OTHER_URN: "someone else"})
+
+        assert (urn, secret_id) == (OTHER_URN, "secret://minted")
+        create_sa.assert_called_once()
+        # The stale secret held a token for a service account that no longer exists.
+        rel.charm.model.get_secret.return_value.remove_all_revisions.assert_called_once()
+
+    def test_mints_a_new_token_when_secret_is_missing(self):
+        """A live service account whose secret was lost gets a fresh token, same account."""
+        rel = _client_relation(known_urn=SA_URN, published_secret_id=None, secret_exists=False)
+        with (
+            patch("graphql.create_service_account") as create_sa,
+            patch("graphql.create_access_token", return_value="pat"),
+        ):
+            urn, secret_id = rel._ensure_credentials(_relation(), {SA_URN: "[juju] x-7"})
+
+        assert (urn, secret_id) == (SA_URN, "secret://minted")
+        create_sa.assert_not_called()
+
+    def test_ignores_a_published_secret_that_no_longer_exists(self):
+        """A dangling secret ID must not be handed to the requirer."""
+        rel = _client_relation(known_urn=SA_URN, secret_exists=False)
+        with patch("graphql.create_access_token", return_value="pat"):
+            urn, secret_id = rel._ensure_credentials(_relation(), {SA_URN: "[juju] x-7"})
+
+        assert (urn, secret_id) == (SA_URN, "secret://minted")
+
+
+class TestReconcileClients:
+    """Tests for the reconcile entry point."""
+
+    def test_publishes_connection_for_each_relation(self):
+        """Each relation is provisioned and its connection details published."""
+        rel = _client_relation(known_urn=SA_URN)
+        relation = _relation()
+        rel.charm.model.relations = {literals.DATAHUB_CLIENT_RELATION_NAME: [relation]}
+        with patch("graphql.list_service_accounts", return_value={SA_URN: "[juju] datahub-mcp-k8s-7"}):
+            rel.reconcile_clients()
+
+        rel.provider.publish_connection.assert_called_once_with(relation, CLUSTER_URL, "secret://existing", SA_URN)
+
+    def test_one_failing_relation_does_not_block_the_others(self):
+        """A GraphQL failure is logged and the next relation is still provisioned."""
+        rel = _client_relation(known_urn=SA_URN)
+        rel.charm.model.relations = {literals.DATAHUB_CLIENT_RELATION_NAME: [_relation(1), _relation(2)]}
+        with (
+            patch("graphql.list_service_accounts", return_value={SA_URN: "[juju] datahub-mcp-k8s-1"}),
+            patch("graphql.create_service_account", side_effect=[RuntimeError("gms down"), OTHER_URN]),
+            patch("graphql.create_access_token", return_value="pat"),
+        ):
+            rel.provider.get_service_account_urn.return_value = None
+            rel.reconcile_clients()
+
+        assert rel.provider.publish_connection.call_count == 1
+
+
+class TestDeleteObsoletes:
+    """Tests for the obsolete service account sweep."""
+
+    def test_deletes_accounts_whose_relation_is_gone(self):
+        """A relation-broken cleanup that failed while GMS was down self-heals."""
+        rel = _client_relation()
+        accounts = {SA_URN: "[juju] datahub-mcp-k8s-7", OTHER_URN: "[juju] datahub-mcp-k8s-9"}
+        with patch("graphql.delete_service_account") as delete_sa:
+            rel._delete_obsolete_accounts(accounts, {7})
+
+        delete_sa.assert_called_once_with("__datahub_system", "sys-secret", OTHER_URN)
+
+    def test_leaves_accounts_it_does_not_manage(self):
+        """Service accounts a human created must survive reconcile."""
+        rel = _client_relation()
+        with patch("graphql.delete_service_account") as delete_sa:
+            rel._delete_obsolete_accounts({OTHER_URN: "analytics-bot"}, set())
+
+        delete_sa.assert_not_called()
+
+
+class TestRelationBroken:
+    """Tests for relation-broken cleanup."""
+
+    def test_deletes_service_account_and_secret(self):
+        """Deleting the service account invalidates every token issued for it."""
+        rel = _client_relation(known_urn=SA_URN)
+        event = SimpleNamespace(relation=_relation())
+        with patch("graphql.delete_service_account") as delete_sa:
+            rel._on_relation_broken(event)
+
+        delete_sa.assert_called_once_with("__datahub_system", "sys-secret", SA_URN)
+        rel.charm.model.get_secret.assert_called_with(id="secret://existing")
+        rel.charm.model.get_secret.return_value.remove_all_revisions.assert_called_once()
+        rel.charm.reconcile.assert_called_once()
+
+    def test_non_leader_does_nothing(self):
+        """Only the leader owns the DataHub-side resources."""
+        rel = _client_relation(known_urn=SA_URN)
+        rel.charm.unit.is_leader.return_value = False
+        with patch("graphql.delete_service_account") as delete_sa:
+            rel._on_relation_broken(SimpleNamespace(relation=_relation()))
+
+        delete_sa.assert_not_called()
+        rel.charm.reconcile.assert_not_called()
+
+
+FULL_DATABAG = {
+    "gms-url": "http://gms:8080",
+    "secret-id": "secret://x",
+    "service-account-urn": SA_URN,
+}
+
+
+def _requirer(databag, token="pat"):  # nosec B107
+    """Build a DatahubClientRequirer reading the given provider databag."""
+    charm = MagicMock()
+    remote_app = MagicMock()
+    relation = SimpleNamespace(app=remote_app, data={remote_app: databag})
+    charm.model.relations = {"datahub-client": [relation]}
+    charm.model.get_secret.return_value.get_content.return_value = {"token": token}
+
+    requirer = DatahubClientRequirer.__new__(DatahubClientRequirer)
+    requirer.charm = charm
+    requirer.relation_name = "datahub-client"
+    return requirer
+
+
+@pytest.mark.parametrize(
+    "databag",
+    [
+        {},
+        {"gms-url": "http://gms:8080"},
+        {"gms-url": "http://gms:8080", "secret-id": "secret://x"},
+    ],
+)
+def test_requirer_waits_for_complete_data(databag):
+    """The requirer reports no connection until every field is published."""
+    assert _requirer(databag).get_connection() is None
+
+
+def test_requirer_returns_connection_when_complete():
+    """A complete databag plus a readable secret yields the connection."""
+    connection = _requirer(FULL_DATABAG).get_connection()
+
+    assert connection is not None
+    assert connection.gms_url == "http://gms:8080"
+    assert connection.token == "pat"  # nosec B105
+    assert connection.service_account_urn == SA_URN
+
+
+def test_requirer_waits_for_a_readable_secret():
+    """A granted-but-not-yet-readable secret is not an error, just not ready."""
+    requirer = _requirer(FULL_DATABAG)
+    requirer.charm.model.get_secret.side_effect = ops.ModelError("permission denied")
+
+    assert requirer.get_connection() is None


### PR DESCRIPTION
This PR introduces the new `datahub_client` interface and its provider implementation.

The interface lets a charm consume the DataHub GMS API as a dedicated DataHub service account. The provider creates the service account, mints a Personal Access Token for it, stores the token in a Juju secret granted to the relation, and publishes the GMS URL alongside the secret ID. The requirer reads both and configures its workload.